### PR TITLE
feat: transcript-based session context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,12 @@ This project uses `docket` for feature tracking. Dashboard: http://localhost:<po
 
 Start of work (after any brainstorming/planning) — call `get_ready` to find existing features, then dispatch `board-manager` agent (model: sonnet) to create or find a card. Use `type` param (feature/bugfix/chore/spike) to auto-generate subtask templates.
 
+Use `tags` param (comma-separated) on `add_feature`/`update_feature` to categorize work. New tags warn about existing tags to prevent typos.
+
+Done features are auto-archived after 7 days. Use `list_features(status="archived")` to see them. `update_feature(status="planned")` to unarchive.
+
 After a commit — use **direct MCP calls**, not agent dispatch:
-- `update_feature` — set left_off, key_files, status. Completion gate blocks `done` with unchecked items — pass `force=true` + `force_reason` to override.
+- `update_feature` — set left_off, key_files, status, tags. Completion gate blocks `done` with unchecked items — pass `force=true` + `force_reason` to override.
 - `complete_task_item` — check off items with outcome and commit_hash (pass `items` JSON array for batch)
 - `add_decision` — record notable decisions (accepted/rejected with reason)
 - `add_issue` / `resolve_issue` — track bugs found during work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ Use `tags` param (comma-separated) on `add_feature`/`update_feature` to categori
 
 Done features are auto-archived after 7 days. Use `list_features(status="archived")` to see them. `update_feature(status="planned")` to unarchive.
 
+**Plan execution (superpowers):** When using executing-plans or subagent-driven-development, set up docket BEFORE dispatching the first task — call `get_ready`, create/find a feature card, and use `add_task_item` for each plan task. A PreToolUse hook will remind you if you forget.
+
 After a commit — use **direct MCP calls**, not agent dispatch:
 - `update_feature` — set left_off, key_files, status, tags. Completion gate blocks `done` with unchecked items — pass `force=true` + `force_reason` to override.
 - `complete_task_item` — check off items with outcome and commit_hash (pass `items` JSON array for batch)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,15 +25,24 @@ Builds binary to `~/.local/share/docket/docket.exe`, installs plugin to `~/.clau
 ## Key Files
 
 - `cmd/docket/main.go` — entry point (serve, init, version commands)
-- `cmd/docket/hook.go` — SessionStart/PostToolUse/Stop hook handlers
-- `cmd/docket/handoff.go` — handoff file renderer and writer
+- `cmd/docket/hook.go` — hook handlers (SessionStart, PreToolUse, PostToolUse, Stop, PreCompact, SessionEnd)
+- `cmd/docket/handoff.go` — thin wrappers delegating to internal/handoff
 - `cmd/docket/update.go` — CLAUDE.md snippet sync command
 - `cmd/docket/export.go` — handoff file export for context resets
 - `internal/mcp/tools.go` — tool registration (18 tools), handlers split across tools_*.go
+- `internal/mcp/tools_checkpoint.go` — checkpoint MCP tool, transcript path finder
 - `internal/store/store.go` — SQLite data layer, Feature/FeatureUpdate structs, completion gate
-- `internal/store/migrate.go` — schema migrations (v1-v7)
+- `internal/store/migrate.go` — schema migrations (v1-v11)
+- `internal/store/checkpoint.go` — checkpoint job queue + observation CRUD
+- `internal/store/worksession.go` — work session CRUD (open, close, get active)
 - `internal/store/templates.go` — feature type templates (feature/bugfix/chore/spike)
 - `internal/store/import.go` — plan file parser (regex-based markdown → subtasks)
+- `internal/transcript/parse.go` — JSONL transcript parser (byte-offset delta extraction)
+- `internal/transcript/types.go` — Delta struct, trivial message map
+- `internal/checkpoint/worker.go` — background job queue worker (polls, summarizes, writes observations)
+- `internal/checkpoint/anthropic.go` — Anthropic Messages API summarizer
+- `internal/checkpoint/config.go` — checkpoint config from env vars
+- `internal/handoff/render.go` — shared handoff rendering (used by hooks and MCP tools)
 - `dashboard/index.html` — single-file frontend (embedded via Go embed)
 - `plugin/` — Claude Code plugin (agent, skills, hooks, MCP config)
 
@@ -55,8 +64,11 @@ Both read/write the same SQLite database at `<project>/.docket/features.db`.
 
 ## Hook / MCP IPC
 
-- `log_session` MCP handler writes `.docket/session-logged` sentinel file. Stop hook checks for it to avoid double-logging. Cleared after each stop cycle.
-- `commits.log` is written by PostToolUse hook, read by Stop hook. Cleared after handoff.
+- `commits.log` is written by PostToolUse hook (records commit hashes). Cleared by SessionEnd hook after handoff.
+- `transcript-offset` file tracks byte offset into Claude's JSONL transcript. Reset at SessionStart, advanced after each checkpoint.
+- Stop hook enqueues checkpoint jobs when transcript delta is meaningful (commits, errors, failed tests, 300+ chars, or non-trivial user input).
+- PreCompact hook always checkpoints (no threshold — context compression means data loss).
+- SessionEnd hook enqueues remaining delta, writes handoff files, closes work session.
 
 ## Adding Schema Migrations
 

--- a/cmd/docket/handoff.go
+++ b/cmd/docket/handoff.go
@@ -9,7 +9,12 @@ import (
 	"github.com/sniffle6/claude-docket/internal/store"
 )
 
-func renderHandoff(data *store.HandoffData) string {
+type HandoffCheckpointData struct {
+	Observations    []store.CheckpointObservation
+	MechanicalFacts *store.MechanicalFacts
+}
+
+func renderHandoff(data *store.HandoffData, cpData *HandoffCheckpointData) string {
 	var b strings.Builder
 	f := data.Feature
 
@@ -21,6 +26,61 @@ func renderHandoff(data *store.HandoffData) string {
 
 	if f.LeftOff != "" {
 		fmt.Fprintf(&b, "## Left Off\n%s\n\n", f.LeftOff)
+	}
+
+	// Last Session section from checkpoint observations
+	if cpData != nil && (len(cpData.Observations) > 0 || cpData.MechanicalFacts != nil) {
+		b.WriteString("## Last Session\n")
+
+		for _, obs := range cpData.Observations {
+			switch obs.Kind {
+			case "summary":
+				fmt.Fprintf(&b, "%s\n\n", obs.SummaryText)
+			case "blocker":
+				fmt.Fprintf(&b, "- **Blocker:** %s\n", obs.SummaryText)
+			case "dead_end":
+				fmt.Fprintf(&b, "- **Dead end:** %s\n", obs.SummaryText)
+			case "next_step":
+				fmt.Fprintf(&b, "- **Next:** %s\n", obs.SummaryText)
+			case "decision_candidate":
+				fmt.Fprintf(&b, "- **Decision:** %s\n", obs.SummaryText)
+			case "gotcha":
+				fmt.Fprintf(&b, "- **Gotcha:** %s\n", obs.SummaryText)
+			}
+		}
+
+		if cpData.MechanicalFacts != nil {
+			mf := cpData.MechanicalFacts
+			if len(mf.FilesEdited) > 0 {
+				var parts []string
+				for _, fe := range mf.FilesEdited {
+					if fe.Count > 1 {
+						parts = append(parts, fmt.Sprintf("%s (%d×)", fe.Path, fe.Count))
+					} else {
+						parts = append(parts, fe.Path)
+					}
+				}
+				fmt.Fprintf(&b, "\nFiles: %s\n", strings.Join(parts, ", "))
+			}
+			if len(mf.TestRuns) > 0 {
+				passed := 0
+				for _, tr := range mf.TestRuns {
+					if tr.Passed {
+						passed++
+					}
+				}
+				fmt.Fprintf(&b, "Tests: %d runs (%d passed, %d failed)\n",
+					len(mf.TestRuns), passed, len(mf.TestRuns)-passed)
+			}
+			if len(mf.Commits) > 0 {
+				var msgs []string
+				for _, c := range mf.Commits {
+					msgs = append(msgs, fmt.Sprintf("%q", c.Message))
+				}
+				fmt.Fprintf(&b, "Commits: %s\n", strings.Join(msgs, ", "))
+			}
+		}
+		b.WriteString("\n")
 	}
 
 	if len(data.NextTasks) > 0 {
@@ -71,13 +131,17 @@ var enrichmentHeadings = []string{
 }
 
 func writeHandoffFile(dir string, data *store.HandoffData) error {
+	return writeHandoffFileWithCheckpoints(dir, data, nil)
+}
+
+func writeHandoffFileWithCheckpoints(dir string, data *store.HandoffData, cpData *HandoffCheckpointData) error {
 	handoffDir := filepath.Join(dir, ".docket", "handoff")
 	if err := os.MkdirAll(handoffDir, 0755); err != nil {
 		return err
 	}
 	path := filepath.Join(handoffDir, data.Feature.ID+".md")
 
-	baseline := renderHandoff(data)
+	baseline := renderHandoff(data, cpData)
 
 	// Preserve enrichment sections from board-manager if they exist
 	if existing, err := os.ReadFile(path); err == nil {

--- a/cmd/docket/handoff.go
+++ b/cmd/docket/handoff.go
@@ -1,208 +1,28 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
+	"github.com/sniffle6/claude-docket/internal/handoff"
 	"github.com/sniffle6/claude-docket/internal/store"
 )
 
-type HandoffCheckpointData struct {
-	Observations    []store.CheckpointObservation
-	MechanicalFacts *store.MechanicalFacts
-}
+type HandoffCheckpointData = handoff.CheckpointData
 
 func renderHandoff(data *store.HandoffData, cpData *HandoffCheckpointData) string {
-	var b strings.Builder
-	f := data.Feature
-
-	fmt.Fprintf(&b, "# Handoff: %s\n\n", f.Title)
-
-	fmt.Fprintf(&b, "## Status\n")
-	fmt.Fprintf(&b, "%s | Progress: %d/%d | Updated: %s\n\n",
-		f.Status, data.Done, data.Total, f.UpdatedAt.Format("2006-01-02 15:04"))
-
-	if f.LeftOff != "" {
-		fmt.Fprintf(&b, "## Left Off\n%s\n\n", f.LeftOff)
-	}
-
-	// Last Session section from checkpoint observations
-	if cpData != nil && (len(cpData.Observations) > 0 || cpData.MechanicalFacts != nil) {
-		b.WriteString("## Last Session\n")
-
-		for _, obs := range cpData.Observations {
-			switch obs.Kind {
-			case "summary":
-				fmt.Fprintf(&b, "%s\n\n", obs.SummaryText)
-			case "blocker":
-				fmt.Fprintf(&b, "- **Blocker:** %s\n", obs.SummaryText)
-			case "dead_end":
-				fmt.Fprintf(&b, "- **Dead end:** %s\n", obs.SummaryText)
-			case "next_step":
-				fmt.Fprintf(&b, "- **Next:** %s\n", obs.SummaryText)
-			case "decision_candidate":
-				fmt.Fprintf(&b, "- **Decision:** %s\n", obs.SummaryText)
-			case "gotcha":
-				fmt.Fprintf(&b, "- **Gotcha:** %s\n", obs.SummaryText)
-			}
-		}
-
-		if cpData.MechanicalFacts != nil {
-			mf := cpData.MechanicalFacts
-			if len(mf.FilesEdited) > 0 {
-				var parts []string
-				for _, fe := range mf.FilesEdited {
-					if fe.Count > 1 {
-						parts = append(parts, fmt.Sprintf("%s (%d×)", fe.Path, fe.Count))
-					} else {
-						parts = append(parts, fe.Path)
-					}
-				}
-				fmt.Fprintf(&b, "\nFiles: %s\n", strings.Join(parts, ", "))
-			}
-			if len(mf.TestRuns) > 0 {
-				passed := 0
-				for _, tr := range mf.TestRuns {
-					if tr.Passed {
-						passed++
-					}
-				}
-				fmt.Fprintf(&b, "Tests: %d runs (%d passed, %d failed)\n",
-					len(mf.TestRuns), passed, len(mf.TestRuns)-passed)
-			}
-			if len(mf.Commits) > 0 {
-				var msgs []string
-				for _, c := range mf.Commits {
-					msgs = append(msgs, fmt.Sprintf("%q", c.Message))
-				}
-				fmt.Fprintf(&b, "Commits: %s\n", strings.Join(msgs, ", "))
-			}
-		}
-		b.WriteString("\n")
-	}
-
-	if len(data.NextTasks) > 0 {
-		b.WriteString("## Next Tasks\n")
-		for _, task := range data.NextTasks {
-			fmt.Fprintf(&b, "- [ ] %s\n", task)
-		}
-		b.WriteString("\n")
-	}
-
-	if len(f.KeyFiles) > 0 {
-		b.WriteString("## Key Files\n")
-		for _, kf := range f.KeyFiles {
-			fmt.Fprintf(&b, "- %s\n", kf)
-		}
-		b.WriteString("\n")
-	}
-
-	if len(data.RecentSessions) > 0 {
-		b.WriteString("## Recent Activity\n")
-		for _, sess := range data.RecentSessions {
-			line := fmt.Sprintf("- %s: %s", sess.CreatedAt.Format("2006-01-02"), sess.Summary)
-			if len(sess.Commits) > 0 {
-				line += fmt.Sprintf(" [%s]", strings.Join(sess.Commits, ", "))
-			}
-			fmt.Fprintf(&b, "%s\n", line)
-		}
-		b.WriteString("\n")
-	}
-
-	if len(data.SubtaskSummary) > 0 {
-		b.WriteString("## Active Subtasks\n")
-		for _, st := range data.SubtaskSummary {
-			fmt.Fprintf(&b, "- %s [%d/%d]\n", st.Title, st.Done, st.Total)
-		}
-		b.WriteString("\n")
-	}
-
-	return b.String()
-}
-
-// enrichmentHeadings are sections written by board-manager that should be
-// preserved when the Stop hook rewrites the mechanical baseline.
-var enrichmentHeadings = []string{
-	"## Decisions & Context",
-	"## Gotchas",
-	"## Recommended Approach",
+	return handoff.Render(data, cpData)
 }
 
 func writeHandoffFile(dir string, data *store.HandoffData) error {
-	return writeHandoffFileWithCheckpoints(dir, data, nil)
+	return handoff.WriteFile(dir, data, nil)
 }
 
 func writeHandoffFileWithCheckpoints(dir string, data *store.HandoffData, cpData *HandoffCheckpointData) error {
-	handoffDir := filepath.Join(dir, ".docket", "handoff")
-	if err := os.MkdirAll(handoffDir, 0755); err != nil {
-		return err
-	}
-	path := filepath.Join(handoffDir, data.Feature.ID+".md")
-
-	baseline := renderHandoff(data, cpData)
-
-	// Preserve enrichment sections from board-manager if they exist
-	if existing, err := os.ReadFile(path); err == nil {
-		enrichment := extractEnrichmentSections(string(existing))
-		if enrichment != "" {
-			baseline = strings.TrimRight(baseline, "\n") + "\n" + enrichment
-		}
-	}
-
-	return os.WriteFile(path, []byte(baseline), 0644)
+	return handoff.WriteFile(dir, data, cpData)
 }
 
-// extractEnrichmentSections pulls board-manager-written sections from an
-// existing handoff file. Returns the combined text or "" if none found.
 func extractEnrichmentSections(content string) string {
-	var sections []string
-	for _, heading := range enrichmentHeadings {
-		idx := strings.Index(content, heading)
-		if idx < 0 {
-			continue
-		}
-		section := content[idx:]
-		// Find end: next ## heading that isn't one of our enrichment headings,
-		// or EOF
-		rest := section[len(heading):]
-		endIdx := strings.Index(rest, "\n## ")
-		if endIdx >= 0 {
-			// Check if the next heading is another enrichment heading
-			nextSection := rest[endIdx+1:]
-			isEnrichment := false
-			for _, eh := range enrichmentHeadings {
-				if strings.HasPrefix(nextSection, eh) {
-					isEnrichment = true
-					break
-				}
-			}
-			if !isEnrichment {
-				section = section[:len(heading)+endIdx+1]
-			}
-		}
-		sections = append(sections, strings.TrimRight(section, "\n"))
-	}
-	if len(sections) == 0 {
-		return ""
-	}
-	return "\n" + strings.Join(sections, "\n\n") + "\n"
+	return handoff.ExtractEnrichmentSections(content)
 }
 
 func cleanStaleHandoffs(dir string, activeIDs map[string]bool) {
-	handoffDir := filepath.Join(dir, ".docket", "handoff")
-	entries, err := os.ReadDir(handoffDir)
-	if err != nil {
-		return
-	}
-	for _, e := range entries {
-		if !strings.HasSuffix(e.Name(), ".md") {
-			continue
-		}
-		name := strings.TrimSuffix(e.Name(), ".md")
-		if !activeIDs[name] {
-			os.Remove(filepath.Join(handoffDir, e.Name()))
-		}
-	}
+	handoff.CleanStale(dir, activeIDs)
 }

--- a/cmd/docket/handoff_test.go
+++ b/cmd/docket/handoff_test.go
@@ -37,7 +37,7 @@ func TestRenderHandoff(t *testing.T) {
 		},
 	}
 
-	result := renderHandoff(data)
+	result := renderHandoff(data, nil)
 
 	checks := []string{
 		"# Handoff: Auth System",
@@ -76,7 +76,7 @@ func TestRenderHandoffMinimal(t *testing.T) {
 		},
 	}
 
-	result := renderHandoff(data)
+	result := renderHandoff(data, nil)
 
 	if !strings.Contains(result, "# Handoff: Simple Feature") {
 		t.Errorf("missing title in output:\n%s", result)

--- a/cmd/docket/hook.go
+++ b/cmd/docket/hook.go
@@ -259,7 +259,7 @@ func handleSessionEnd(h *hookInput, w io.Writer) {
 		s.EnqueueCheckpointJob(store.CheckpointJobInput{
 			WorkSessionID:         ws.ID,
 			FeatureID:             ws.FeatureID,
-			Reason:                "stop",
+			Reason:                "session_end",
 			TriggerType:           "auto",
 			TranscriptStartOffset: getTranscriptOffset(h.CWD),
 			TranscriptEndOffset:   delta.EndOffset,

--- a/cmd/docket/hook.go
+++ b/cmd/docket/hook.go
@@ -35,6 +35,15 @@ type stopHookOutput struct {
 	Reason   string `json:"reason,omitempty"`
 }
 
+type preToolUseOutput struct {
+	HookSpecificOutput *preToolUseDecision `json:"hookSpecificOutput,omitempty"`
+	SystemMessage      string              `json:"systemMessage,omitempty"`
+}
+
+type preToolUseDecision struct {
+	PermissionDecision string `json:"permissionDecision"`
+}
+
 func runHook() {
 	var h hookInput
 	if err := json.NewDecoder(os.Stdin).Decode(&h); err != nil {
@@ -55,6 +64,8 @@ func runHook() {
 	}
 
 	switch h.HookEventName {
+	case "PreToolUse":
+		handlePreToolUse(&h, os.Stdout)
 	case "SessionStart":
 		handleSessionStart(&h, os.Stdout)
 	case "PostToolUse":
@@ -84,6 +95,10 @@ func handleSessionStart(h *hookInput, w io.Writer) {
 	// Create/clear commits.log
 	commitsPath := filepath.Join(h.CWD, ".docket", "commits.log")
 	os.WriteFile(commitsPath, []byte{}, 0644)
+
+	// Clear agent-nudged sentinel for new session
+	sentinelPath := filepath.Join(h.CWD, ".docket", "agent-nudged")
+	os.Remove(sentinelPath)
 
 	features, err := s.ListFeatures("in_progress")
 	if err != nil {
@@ -246,6 +261,59 @@ Then call update_feature to set left_off to a brief note about where things stan
 
 	// No active feature or no commits — allow stop
 	json.NewEncoder(w).Encode(stopHookOutput{})
+}
+
+func handlePreToolUse(h *hookInput, w io.Writer) {
+	allow := preToolUseOutput{
+		HookSpecificOutput: &preToolUseDecision{PermissionDecision: "allow"},
+	}
+
+	// Check sentinel — already nudged this session
+	sentinelPath := filepath.Join(h.CWD, ".docket", "agent-nudged")
+	if _, err := os.Stat(sentinelPath); err == nil {
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	s, err := store.Open(h.CWD)
+	if err != nil {
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+	defer s.Close()
+
+	features, err := s.ListFeatures("in_progress")
+	if err != nil {
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	if len(features) == 0 {
+		os.WriteFile(sentinelPath, []byte{}, 0644)
+		allow.SystemMessage = "[docket] No active docket feature. Call get_ready to set up tracking before dispatching subagents."
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	// Check if top feature has task items
+	_, total, err := s.GetFeatureProgress(features[0].ID)
+	if err != nil {
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	if total == 0 {
+		os.WriteFile(sentinelPath, []byte{}, 0644)
+		allow.SystemMessage = fmt.Sprintf(
+			"[docket] Active feature %q (id: %s) has no task items. Add task items from the plan before dispatching subagents.",
+			features[0].Title, features[0].ID,
+		)
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	// Feature has task items — all good
+	json.NewEncoder(w).Encode(allow)
 }
 
 func handlePostToolUse(h *hookInput, w io.Writer) {

--- a/cmd/docket/hook.go
+++ b/cmd/docket/hook.go
@@ -274,10 +274,24 @@ func handleSessionEnd(h *hookInput, w io.Writer) {
 		for _, f := range features {
 			activeIDs[f.ID] = true
 			data, err := s.GetHandoffData(f.ID)
-			if err == nil {
-				if writeErr := writeHandoffFile(h.CWD, data); writeErr != nil {
-					s.MarkHandoffStale(ws.ID)
+			if err != nil {
+				continue
+			}
+
+			var cpData *HandoffCheckpointData
+			if f.ID == ws.FeatureID {
+				obs, _ := s.GetObservationsForWorkSession(ws.ID)
+				mf, _ := s.GetMechanicalFactsForWorkSession(ws.ID)
+				if len(obs) > 0 || mf != nil {
+					cpData = &HandoffCheckpointData{
+						Observations:    obs,
+						MechanicalFacts: mf,
+					}
 				}
+			}
+
+			if writeErr := writeHandoffFileWithCheckpoints(h.CWD, data, cpData); writeErr != nil {
+				s.MarkHandoffStale(ws.ID)
 			}
 		}
 		cleanStaleHandoffs(h.CWD, activeIDs)

--- a/cmd/docket/hook.go
+++ b/cmd/docket/hook.go
@@ -75,6 +75,11 @@ func handleSessionStart(h *hookInput, w io.Writer) {
 	}
 	defer s.Close()
 
+	// Auto-archive features done >7 days
+	if archived, err := s.AutoArchiveStale(); err == nil && len(archived) > 0 {
+		fmt.Fprintf(os.Stderr, "[docket] Auto-archived %d features: %s\n", len(archived), strings.Join(archived, ", "))
+	}
+
 	// Create/clear commits.log
 	commitsPath := filepath.Join(h.CWD, ".docket", "commits.log")
 	os.WriteFile(commitsPath, []byte{}, 0644)

--- a/cmd/docket/hook.go
+++ b/cmd/docket/hook.go
@@ -19,9 +19,8 @@ type hookInput struct {
 	CWD            string    `json:"cwd"`
 	HookEventName  string    `json:"hook_event_name"`
 	ToolName       string    `json:"tool_name"`
-	ToolInput      toolInput `json:"tool_input"`
-	StopHookActive bool      `json:"stop_hook_active"`
-	Trigger        string    `json:"trigger"`
+	ToolInput toolInput `json:"tool_input"`
+	Trigger   string    `json:"trigger"`
 }
 
 type toolInput struct {

--- a/cmd/docket/hook.go
+++ b/cmd/docket/hook.go
@@ -76,8 +76,9 @@ func handleSessionStart(h *hookInput, w io.Writer) {
 	defer s.Close()
 
 	// Auto-archive features done >7 days
+	var archiveMsg string
 	if archived, err := s.AutoArchiveStale(); err == nil && len(archived) > 0 {
-		fmt.Fprintf(os.Stderr, "[docket] Auto-archived %d features: %s\n", len(archived), strings.Join(archived, ", "))
+		archiveMsg = fmt.Sprintf("[docket] Auto-archived %d features done >7 days: %s\n", len(archived), strings.Join(archived, ", "))
 	}
 
 	// Create/clear commits.log
@@ -94,7 +95,7 @@ func handleSessionStart(h *hookInput, w io.Writer) {
 	out := hookOutput{Continue: true}
 
 	if len(features) == 0 {
-		out.SystemMessage = "[docket] No active features. Use docket MCP tools to create one."
+		out.SystemMessage = archiveMsg + "[docket] No active features. Use docket MCP tools to create one."
 		json.NewEncoder(w).Encode(out)
 		return
 	}
@@ -139,7 +140,7 @@ func handleSessionStart(h *hookInput, w io.Writer) {
 		}
 	}
 
-	out.SystemMessage = msg.String()
+	out.SystemMessage = archiveMsg + msg.String()
 	json.NewEncoder(w).Encode(out)
 }
 

--- a/cmd/docket/hook.go
+++ b/cmd/docket/hook.go
@@ -10,15 +10,18 @@ import (
 	"strings"
 
 	"github.com/sniffle6/claude-docket/internal/store"
+	"github.com/sniffle6/claude-docket/internal/transcript"
 )
 
 type hookInput struct {
 	SessionID      string    `json:"session_id"`
+	TranscriptPath string    `json:"transcript_path"`
 	CWD            string    `json:"cwd"`
 	HookEventName  string    `json:"hook_event_name"`
 	ToolName       string    `json:"tool_name"`
 	ToolInput      toolInput `json:"tool_input"`
 	StopHookActive bool      `json:"stop_hook_active"`
+	Trigger        string    `json:"trigger"`
 }
 
 type toolInput struct {
@@ -55,7 +58,7 @@ func runHook() {
 	docketDir := filepath.Join(h.CWD, ".docket")
 	if _, err := os.Stat(docketDir); os.IsNotExist(err) {
 		// Not a docket project — pass through silently
-		if h.HookEventName == "Stop" {
+		if h.HookEventName == "Stop" || h.HookEventName == "SessionEnd" {
 			json.NewEncoder(os.Stdout).Encode(stopHookOutput{})
 		} else {
 			json.NewEncoder(os.Stdout).Encode(hookOutput{Continue: true})
@@ -72,6 +75,10 @@ func runHook() {
 		handlePostToolUse(&h, os.Stdout)
 	case "Stop":
 		handleStop(&h, os.Stdout)
+	case "PreCompact":
+		handlePreCompact(&h, os.Stdout)
+	case "SessionEnd":
+		handleSessionEnd(&h, os.Stdout)
 	default:
 		json.NewEncoder(os.Stdout).Encode(hookOutput{Continue: true})
 	}
@@ -100,6 +107,10 @@ func handleSessionStart(h *hookInput, w io.Writer) {
 	sentinelPath := filepath.Join(h.CWD, ".docket", "agent-nudged")
 	os.Remove(sentinelPath)
 
+	// Reset transcript offset for new session
+	offsetPath := filepath.Join(h.CWD, ".docket", "transcript-offset")
+	os.WriteFile(offsetPath, []byte("0"), 0644)
+
 	features, err := s.ListFeatures("in_progress")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "docket hook: list features: %v\n", err)
@@ -117,6 +128,9 @@ func handleSessionStart(h *hookInput, w io.Writer) {
 
 	var msg strings.Builder
 	topFeature := features[0]
+
+	s.OpenWorkSession(topFeature.ID, h.SessionID)
+
 	handoffPath := filepath.Join(h.CWD, ".docket", "handoff", topFeature.ID+".md")
 
 	if content, err := os.ReadFile(handoffPath); err == nil {
@@ -160,18 +174,6 @@ func handleSessionStart(h *hookInput, w io.Writer) {
 }
 
 func handleStop(h *hookInput, w io.Writer) {
-	// Read commits.log if it exists
-	commitsPath := filepath.Join(h.CWD, ".docket", "commits.log")
-	var commits []string
-	if data, err := os.ReadFile(commitsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
-		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
-			if line != "" {
-				commits = append(commits, line)
-			}
-		}
-	}
-
-	// Find active feature
 	s, err := store.Open(h.CWD)
 	if err != nil {
 		json.NewEncoder(w).Encode(stopHookOutput{})
@@ -179,87 +181,112 @@ func handleStop(h *hookInput, w io.Writer) {
 	}
 	defer s.Close()
 
-	features, err := s.ListFeatures("in_progress")
+	ws, err := s.GetActiveWorkSession()
 	if err != nil {
 		json.NewEncoder(w).Encode(stopHookOutput{})
 		return
 	}
 
-	// Re-trigger (second stop): write handoff files and allow stop
-	if h.StopHookActive {
-		// Fallback: if Claude didn't call log_session, log a mechanical summary
-		if len(features) > 0 && len(commits) > 0 && !s.WasSessionLogged() {
-			f := features[0]
-			var summaryParts []string
-			var commitHashes []string
-			for _, c := range commits {
-				parts := strings.SplitN(c, "|||", 2)
-				if len(parts) == 2 {
-					commitHashes = append(commitHashes, parts[0])
-					summaryParts = append(summaryParts, parts[1])
-				}
-			}
-			if len(commitHashes) > 0 {
-				summary := fmt.Sprintf("%d commit(s): %s", len(commitHashes), strings.Join(summaryParts, "; "))
-				s.LogSession(store.SessionInput{
-					FeatureID: f.ID,
-					Summary:   summary,
-					Commits:   commitHashes,
-				})
-			}
-		}
-		s.ClearSessionLogged()
-
-		if len(commits) > 0 {
-			os.Remove(commitsPath)
-		}
-		if len(features) > 0 {
-			activeIDs := make(map[string]bool)
-			for _, f := range features {
-				activeIDs[f.ID] = true
-				data, err := s.GetHandoffData(f.ID)
-				if err == nil {
-					writeHandoffFile(h.CWD, data)
-				}
-			}
-			cleanStaleHandoffs(h.CWD, activeIDs)
-		}
+	delta := parseTranscriptDelta(h)
+	if !isDeltaMeaningful(h.CWD, delta) {
 		json.NewEncoder(w).Encode(stopHookOutput{})
 		return
 	}
 
-	// First stop: if active feature with commits, block and prompt for rich summary
-	if len(features) > 0 && len(commits) > 0 {
-		f := features[0]
+	s.EnqueueCheckpointJob(store.CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             ws.FeatureID,
+		Reason:                "stop",
+		TriggerType:           "auto",
+		TranscriptStartOffset: getTranscriptOffset(h.CWD),
+		TranscriptEndOffset:   delta.EndOffset,
+		SemanticText:          delta.SemanticText,
+		MechanicalFacts:       delta.MechanicalFacts,
+	})
 
-		var commitHashes []string
-		for _, c := range commits {
-			parts := strings.SplitN(c, "|||", 2)
-			if len(parts) == 2 {
-				commitHashes = append(commitHashes, parts[0])
-			}
-		}
+	saveTranscriptOffset(h.CWD, delta.EndOffset)
+	json.NewEncoder(w).Encode(stopHookOutput{})
+}
 
-		reason := fmt.Sprintf(
-			`[docket] Before ending, log a session summary for feature "%s" (id: %s).
+func handlePreCompact(h *hookInput, w io.Writer) {
+	s, err := store.Open(h.CWD)
+	if err != nil {
+		json.NewEncoder(w).Encode(hookOutput{Continue: true})
+		return
+	}
+	defer s.Close()
 
-Call log_session with:
-- feature_id: "%s"
-- summary: Write 3-5 sentences covering: what you worked on, key decisions made, anything you tried that didn't work or gotchas you discovered, and what the next person should know.
-- commits: "%s"
-- files_touched: list the files you modified this session
-
-Then call update_feature to set left_off to a brief note about where things stand.`,
-			f.Title, f.ID, f.ID, strings.Join(commitHashes, ","))
-
-		json.NewEncoder(w).Encode(stopHookOutput{
-			Decision: "block",
-			Reason:   reason,
-		})
+	ws, err := s.GetActiveWorkSession()
+	if err != nil {
+		json.NewEncoder(w).Encode(hookOutput{Continue: true})
 		return
 	}
 
-	// No active feature or no commits — allow stop
+	delta := parseTranscriptDelta(h)
+	startOffset := getTranscriptOffset(h.CWD)
+
+	s.EnqueueCheckpointJob(store.CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             ws.FeatureID,
+		Reason:                "precompact",
+		TriggerType:           h.Trigger,
+		TranscriptStartOffset: startOffset,
+		TranscriptEndOffset:   delta.EndOffset,
+		SemanticText:          delta.SemanticText,
+		MechanicalFacts:       delta.MechanicalFacts,
+	})
+
+	saveTranscriptOffset(h.CWD, delta.EndOffset)
+	json.NewEncoder(w).Encode(hookOutput{Continue: true})
+}
+
+func handleSessionEnd(h *hookInput, w io.Writer) {
+	s, err := store.Open(h.CWD)
+	if err != nil {
+		json.NewEncoder(w).Encode(stopHookOutput{})
+		return
+	}
+	defer s.Close()
+
+	ws, err := s.GetActiveWorkSession()
+	if err != nil {
+		json.NewEncoder(w).Encode(stopHookOutput{})
+		return
+	}
+
+	delta := parseTranscriptDelta(h)
+	if delta.HasContent {
+		s.EnqueueCheckpointJob(store.CheckpointJobInput{
+			WorkSessionID:         ws.ID,
+			FeatureID:             ws.FeatureID,
+			Reason:                "stop",
+			TriggerType:           "auto",
+			TranscriptStartOffset: getTranscriptOffset(h.CWD),
+			TranscriptEndOffset:   delta.EndOffset,
+			SemanticText:          delta.SemanticText,
+			MechanicalFacts:       delta.MechanicalFacts,
+		})
+	}
+
+	features, _ := s.ListFeatures("in_progress")
+	if len(features) > 0 {
+		activeIDs := make(map[string]bool)
+		for _, f := range features {
+			activeIDs[f.ID] = true
+			data, err := s.GetHandoffData(f.ID)
+			if err == nil {
+				if writeErr := writeHandoffFile(h.CWD, data); writeErr != nil {
+					s.MarkHandoffStale(ws.ID)
+				}
+			}
+		}
+		cleanStaleHandoffs(h.CWD, activeIDs)
+	}
+
+	commitsPath := filepath.Join(h.CWD, ".docket", "commits.log")
+	os.Remove(commitsPath)
+
+	s.CloseWorkSession(ws.ID)
 	json.NewEncoder(w).Encode(stopHookOutput{})
 }
 
@@ -394,6 +421,66 @@ func handlePostToolUse(h *hookInput, w io.Writer) {
 	}
 	json.NewEncoder(w).Encode(out)
 }
+
+// --- Transcript helpers ---
+
+func parseTranscriptDelta(h *hookInput) *transcript.Delta {
+	if h.TranscriptPath == "" {
+		return &transcript.Delta{}
+	}
+	offset := getTranscriptOffset(h.CWD)
+	delta, err := transcript.Parse(h.TranscriptPath, offset)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "docket hook: parse transcript: %v\n", err)
+		return &transcript.Delta{EndOffset: offset}
+	}
+	return delta
+}
+
+func getTranscriptOffset(cwd string) int64 {
+	data, err := os.ReadFile(filepath.Join(cwd, ".docket", "transcript-offset"))
+	if err != nil {
+		return 0
+	}
+	var offset int64
+	fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &offset)
+	return offset
+}
+
+func saveTranscriptOffset(cwd string, offset int64) {
+	os.WriteFile(
+		filepath.Join(cwd, ".docket", "transcript-offset"),
+		[]byte(fmt.Sprintf("%d", offset)),
+		0644,
+	)
+}
+
+func isDeltaMeaningful(cwd string, delta *transcript.Delta) bool {
+	commitsPath := filepath.Join(cwd, ".docket", "commits.log")
+	if data, err := os.ReadFile(commitsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+		return true
+	}
+	if len(delta.MechanicalFacts.Commits) > 0 {
+		return true
+	}
+	if len(delta.MechanicalFacts.Errors) > 0 {
+		return true
+	}
+	for _, tr := range delta.MechanicalFacts.TestRuns {
+		if !tr.Passed {
+			return true
+		}
+	}
+	if len(delta.SemanticText) >= 300 {
+		return true
+	}
+	if delta.HasContent {
+		return true
+	}
+	return false
+}
+
+// --- Utility functions ---
 
 func getCommitFiles(dir, hash string) []string {
 	cmd := exec.Command("git", "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", hash)

--- a/cmd/docket/hook.go
+++ b/cmd/docket/hook.go
@@ -470,10 +470,12 @@ func saveTranscriptOffset(cwd string, offset int64) {
 }
 
 func isDeltaMeaningful(cwd string, delta *transcript.Delta) bool {
+	// Check commits.log (PostToolUse hook writes here)
 	commitsPath := filepath.Join(cwd, ".docket", "commits.log")
 	if data, err := os.ReadFile(commitsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
 		return true
 	}
+	// Transcript-detected commits
 	if len(delta.MechanicalFacts.Commits) > 0 {
 		return true
 	}
@@ -485,9 +487,12 @@ func isDeltaMeaningful(cwd string, delta *transcript.Delta) bool {
 			return true
 		}
 	}
+	// Substantial conversation volume
 	if len(delta.SemanticText) >= 300 {
 		return true
 	}
+	// Non-trivial user input that didn't meet the 300-char threshold
+	// (e.g. a short but meaningful instruction like "try the other approach")
 	if delta.HasContent {
 		return true
 	}

--- a/cmd/docket/hook_test.go
+++ b/cmd/docket/hook_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sniffle6/claude-docket/internal/store"
+	"github.com/sniffle6/claude-docket/internal/transcript"
 )
 
 func strPtr(s string) *string { return &s }
@@ -90,27 +91,20 @@ func TestSessionStartNoFeatures(t *testing.T) {
 	}
 }
 
-func TestStopWithCommitsAndFeature(t *testing.T) {
+func TestStopNeverBlocks(t *testing.T) {
 	dir := t.TempDir()
-	s, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s, _ := store.Open(dir)
+	s.AddFeature("Test Feature", "test")
+	s.UpdateFeature("test-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+	s.OpenWorkSession("test-feature", "sess-1")
 
-	f, err := s.AddFeature("My Feature", "testing stop hook")
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	s.UpdateFeature(f.ID, store.FeatureUpdate{Status: &status})
+	commitsPath := filepath.Join(dir, ".docket", "commits.log")
+	os.WriteFile(commitsPath, []byte("abc123|||fix bug\n"), 0644)
+	os.WriteFile(filepath.Join(dir, ".docket", "transcript-offset"), []byte("0"), 0644)
 	s.Close()
 
-	// Write a commits.log
-	commitsPath := filepath.Join(dir, ".docket", "commits.log")
-	os.WriteFile(commitsPath, []byte("abc123|||feat: add something\ndef456|||fix: broken thing\n"), 0644)
-
 	h := &hookInput{
-		SessionID:     "test-session",
+		SessionID:     "sess-1",
 		CWD:           dir,
 		HookEventName: "Stop",
 	}
@@ -118,174 +112,11 @@ func TestStopWithCommitsAndFeature(t *testing.T) {
 	var buf bytes.Buffer
 	handleStop(h, &buf)
 
-	// First stop should block and prompt for rich summary
 	var out stopHookOutput
-	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
-		t.Fatalf("decode output: %v", err)
-	}
-	if out.Decision != "block" {
-		t.Errorf("expected decision=block, got: %s", out.Decision)
-	}
-	if !strings.Contains(out.Reason, f.ID) {
-		t.Errorf("expected feature ID in reason, got: %s", out.Reason)
-	}
-	if !strings.Contains(out.Reason, "log_session") {
-		t.Errorf("expected log_session instruction in reason, got: %s", out.Reason)
-	}
-	if !strings.Contains(out.Reason, "abc123") {
-		t.Errorf("expected commit hashes in reason, got: %s", out.Reason)
-	}
+	json.Unmarshal(buf.Bytes(), &out)
 
-	// Commits.log should NOT be deleted yet (cleaned on re-trigger)
-	if _, err := os.Stat(commitsPath); os.IsNotExist(err) {
-		t.Error("expected commits.log to still exist after first stop")
-	}
-
-	// No session should be logged by the hook (Claude does it via MCP)
-	s2, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s2.Close()
-
-	sessions, err := s2.GetSessionsForFeature(f.ID)
-	if err != nil {
-		t.Fatalf("get sessions: %v", err)
-	}
-	if len(sessions) != 0 {
-		t.Fatalf("expected 0 sessions (Claude logs via MCP), got %d", len(sessions))
-	}
-}
-
-func TestStopRetriggerWritesHandoffAndCleans(t *testing.T) {
-	dir := t.TempDir()
-	s, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := s.AddFeature("My Feature", "testing re-trigger")
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	leftOff := "wrote the parser"
-	s.UpdateFeature(f.ID, store.FeatureUpdate{Status: &status, LeftOff: &leftOff})
-	s.Close()
-
-	// Write a commits.log (leftover from first stop)
-	commitsPath := filepath.Join(dir, ".docket", "commits.log")
-	os.WriteFile(commitsPath, []byte("abc123|||feat: add something\n"), 0644)
-
-	h := &hookInput{
-		SessionID:      "test-session",
-		CWD:            dir,
-		HookEventName:  "Stop",
-		StopHookActive: true,
-	}
-
-	var buf bytes.Buffer
-	handleStop(h, &buf)
-
-	// Re-trigger should allow stop (no decision)
-	var out stopHookOutput
-	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
-		t.Fatalf("decode output: %v", err)
-	}
-	if out.Decision != "" {
-		t.Errorf("expected no decision on re-trigger, got: %s", out.Decision)
-	}
-
-	// Commits.log should be cleaned up
-	if _, err := os.Stat(commitsPath); !os.IsNotExist(err) {
-		t.Error("expected commits.log to be deleted on re-trigger")
-	}
-
-	// Handoff file should be written
-	handoffPath := filepath.Join(dir, ".docket", "handoff", f.ID+".md")
-	content, err := os.ReadFile(handoffPath)
-	if err != nil {
-		t.Fatalf("handoff file not created: %v", err)
-	}
-	if !strings.Contains(string(content), "# Handoff: My Feature") {
-		t.Errorf("handoff missing title:\n%s", content)
-	}
-	if !strings.Contains(string(content), "wrote the parser") {
-		t.Errorf("handoff missing left_off:\n%s", content)
-	}
-
-	// Fallback: session should be logged mechanically since Claude didn't call log_session
-	s2, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s2.Close()
-
-	sessions, err := s2.GetSessionsForFeature(f.ID)
-	if err != nil {
-		t.Fatalf("get sessions: %v", err)
-	}
-	if len(sessions) != 1 {
-		t.Fatalf("expected 1 fallback session, got %d", len(sessions))
-	}
-	if !strings.Contains(sessions[0].Summary, "feat: add something") {
-		t.Errorf("expected mechanical summary, got: %s", sessions[0].Summary)
-	}
-}
-
-func TestStopRetriggerNoDoubleLog(t *testing.T) {
-	dir := t.TempDir()
-	s, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := s.AddFeature("My Feature", "testing no double log")
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	s.UpdateFeature(f.ID, store.FeatureUpdate{Status: &status})
-
-	// Simulate Claude having called log_session with the commit hash
-	s.LogSession(store.SessionInput{
-		FeatureID: f.ID,
-		Summary:   "Rich AI summary of the session",
-		Commits:   []string{"abc123"},
-	})
-	s.MarkSessionLogged()
-	s.Close()
-
-	// Write a commits.log with the same commit
-	commitsPath := filepath.Join(dir, ".docket", "commits.log")
-	os.WriteFile(commitsPath, []byte("abc123|||feat: add something\n"), 0644)
-
-	h := &hookInput{
-		SessionID:      "test-session",
-		CWD:            dir,
-		HookEventName:  "Stop",
-		StopHookActive: true,
-	}
-
-	var buf bytes.Buffer
-	handleStop(h, &buf)
-
-	// Should NOT double-log — Claude already logged the session
-	s2, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s2.Close()
-
-	sessions, err := s2.GetSessionsForFeature(f.ID)
-	if err != nil {
-		t.Fatalf("get sessions: %v", err)
-	}
-	if len(sessions) != 1 {
-		t.Fatalf("expected exactly 1 session (no double-log), got %d", len(sessions))
-	}
-	if !strings.Contains(sessions[0].Summary, "Rich AI summary") {
-		t.Errorf("expected Claude's rich summary, got: %s", sessions[0].Summary)
+	if out.Decision == "block" {
+		t.Error("Stop hook must never block")
 	}
 }
 
@@ -314,20 +145,199 @@ func TestStopNoCommitsNoFeatures(t *testing.T) {
 	if out.Decision != "" {
 		t.Errorf("expected no decision, got: %s", out.Decision)
 	}
+}
 
-	// Verify no sessions were logged
-	s2, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
+func TestStopEnqueuesCheckpointWithCommits(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := store.Open(dir)
+	s.AddFeature("My Feature", "testing stop")
+	s.UpdateFeature("my-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+	s.OpenWorkSession("my-feature", "sess-1")
+
+	commitsPath := filepath.Join(dir, ".docket", "commits.log")
+	os.WriteFile(commitsPath, []byte("abc123|||feat: add something\n"), 0644)
+	os.WriteFile(filepath.Join(dir, ".docket", "transcript-offset"), []byte("0"), 0644)
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "sess-1",
+		CWD:           dir,
+		HookEventName: "Stop",
 	}
+
+	var buf bytes.Buffer
+	handleStop(h, &buf)
+
+	var out stopHookOutput
+	json.Unmarshal(buf.Bytes(), &out)
+
+	// Never blocks
+	if out.Decision == "block" {
+		t.Error("Stop hook must never block")
+	}
+
+	// Should have enqueued a checkpoint job
+	s2, _ := store.Open(dir)
 	defer s2.Close()
-
-	sessions, err := s2.GetUnlinkedSessions()
+	job, err := s2.DequeueCheckpointJob()
 	if err != nil {
-		t.Fatalf("get sessions: %v", err)
+		t.Fatalf("dequeue: %v", err)
 	}
-	if len(sessions) != 0 {
-		t.Errorf("expected 0 sessions, got %d", len(sessions))
+	if job == nil {
+		t.Fatal("expected a checkpoint job to be enqueued")
+	}
+	if job.FeatureID != "my-feature" {
+		t.Errorf("job.FeatureID = %q, want %q", job.FeatureID, "my-feature")
+	}
+	if job.Reason != "stop" {
+		t.Errorf("job.Reason = %q, want %q", job.Reason, "stop")
+	}
+}
+
+func TestSessionEndClosesWorkSession(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := store.Open(dir)
+	s.AddFeature("Test Feature", "test")
+	s.UpdateFeature("test-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+	s.OpenWorkSession("test-feature", "sess-1")
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "sess-1",
+		CWD:           dir,
+		HookEventName: "SessionEnd",
+	}
+
+	var buf bytes.Buffer
+	handleSessionEnd(h, &buf)
+
+	s2, _ := store.Open(dir)
+	defer s2.Close()
+	_, err := s2.GetActiveWorkSession()
+	if err == nil {
+		t.Error("expected no active work session after SessionEnd")
+	}
+}
+
+func TestSessionEndWritesHandoffs(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := store.Open(dir)
+	f, _ := s.AddFeature("Handoff Feature", "testing handoff")
+	s.UpdateFeature(f.ID, store.FeatureUpdate{
+		Status: strPtr("in_progress"),
+		LeftOff: strPtr("implementing the parser"),
+	})
+	s.OpenWorkSession(f.ID, "sess-1")
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "sess-1",
+		CWD:           dir,
+		HookEventName: "SessionEnd",
+	}
+
+	var buf bytes.Buffer
+	handleSessionEnd(h, &buf)
+
+	// Verify handoff file was created
+	handoffPath := filepath.Join(dir, ".docket", "handoff", f.ID+".md")
+	content, err := os.ReadFile(handoffPath)
+	if err != nil {
+		t.Fatalf("handoff file not created: %v", err)
+	}
+	if !strings.Contains(string(content), "# Handoff: Handoff Feature") {
+		t.Errorf("handoff missing title:\n%s", content)
+	}
+	if !strings.Contains(string(content), "implementing the parser") {
+		t.Errorf("handoff missing left_off:\n%s", content)
+	}
+}
+
+func TestSessionEndCleansStaleHandoffs(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := store.Open(dir)
+
+	// Create one active and one done feature
+	s.AddFeature("Active Feature", "")
+	s.UpdateFeature("active-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+	s.AddFeature("Done Feature", "")
+	s.UpdateFeature("done-feature", store.FeatureUpdate{Status: strPtr("done")})
+	s.OpenWorkSession("active-feature", "sess-1")
+	s.Close()
+
+	// Create a stale handoff for the done feature
+	handoffDir := filepath.Join(dir, ".docket", "handoff")
+	os.MkdirAll(handoffDir, 0755)
+	os.WriteFile(filepath.Join(handoffDir, "done-feature.md"), []byte("stale"), 0644)
+
+	h := &hookInput{
+		SessionID:     "sess-1",
+		CWD:           dir,
+		HookEventName: "SessionEnd",
+	}
+
+	var buf bytes.Buffer
+	handleSessionEnd(h, &buf)
+
+	// Active feature should have a handoff
+	if _, err := os.Stat(filepath.Join(handoffDir, "active-feature.md")); err != nil {
+		t.Error("active handoff should exist")
+	}
+	// Done feature handoff should be cleaned up
+	if _, err := os.Stat(filepath.Join(handoffDir, "done-feature.md")); !os.IsNotExist(err) {
+		t.Error("stale handoff should be deleted")
+	}
+}
+
+func TestSessionEndCleansCommitsLog(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := store.Open(dir)
+	s.AddFeature("Test Feature", "")
+	s.UpdateFeature("test-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+	s.OpenWorkSession("test-feature", "sess-1")
+	s.Close()
+
+	commitsPath := filepath.Join(dir, ".docket", "commits.log")
+	os.WriteFile(commitsPath, []byte("abc123|||fix bug\n"), 0644)
+
+	h := &hookInput{
+		SessionID:     "sess-1",
+		CWD:           dir,
+		HookEventName: "SessionEnd",
+	}
+
+	var buf bytes.Buffer
+	handleSessionEnd(h, &buf)
+
+	if _, err := os.Stat(commitsPath); !os.IsNotExist(err) {
+		t.Error("expected commits.log to be deleted after SessionEnd")
+	}
+}
+
+func TestSessionStartOpensWorkSession(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := store.Open(dir)
+	s.AddFeature("Test Feature", "test")
+	s.UpdateFeature("test-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "sess-1",
+		CWD:           dir,
+		HookEventName: "SessionStart",
+	}
+
+	var buf bytes.Buffer
+	handleSessionStart(h, &buf)
+
+	s2, _ := store.Open(dir)
+	defer s2.Close()
+	ws, err := s2.GetActiveWorkSession()
+	if err != nil {
+		t.Fatalf("expected active work session, got error: %v", err)
+	}
+	if ws.FeatureID != "test-feature" {
+		t.Errorf("FeatureID = %q, want %q", ws.FeatureID, "test-feature")
 	}
 }
 
@@ -354,87 +364,6 @@ func TestPostToolUseIgnoresNonCommit(t *testing.T) {
 	}
 	if out.SystemMessage != "" {
 		t.Errorf("expected no systemMessage for non-commit, got: %s", out.SystemMessage)
-	}
-}
-
-func TestStopWritesHandoffFile(t *testing.T) {
-	dir := t.TempDir()
-	s, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := s.AddFeature("Handoff Feature", "testing handoff generation")
-	if err != nil {
-		t.Fatal(err)
-	}
-	status := "in_progress"
-	leftOff := "implementing the parser"
-	s.UpdateFeature(f.ID, store.FeatureUpdate{Status: &status, LeftOff: &leftOff})
-	s.Close()
-
-	// Handoff files are written on re-trigger (stop_hook_active=true)
-	h := &hookInput{
-		SessionID:      "test-session",
-		CWD:            dir,
-		HookEventName:  "Stop",
-		StopHookActive: true,
-	}
-
-	var buf bytes.Buffer
-	handleStop(h, &buf)
-
-	// Verify handoff file was created
-	handoffPath := filepath.Join(dir, ".docket", "handoff", f.ID+".md")
-	content, err := os.ReadFile(handoffPath)
-	if err != nil {
-		t.Fatalf("handoff file not created: %v", err)
-	}
-	if !strings.Contains(string(content), "# Handoff: Handoff Feature") {
-		t.Errorf("handoff missing title:\n%s", content)
-	}
-	if !strings.Contains(string(content), "implementing the parser") {
-		t.Errorf("handoff missing left_off:\n%s", content)
-	}
-}
-
-func TestStopCleansStaleHandoffs(t *testing.T) {
-	dir := t.TempDir()
-	s, err := store.Open(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Create one active and one done feature
-	s.AddFeature("Active Feature", "")
-	s.UpdateFeature("active-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
-	s.AddFeature("Done Feature", "")
-	s.UpdateFeature("done-feature", store.FeatureUpdate{Status: strPtr("done")})
-	s.Close()
-
-	// Create a stale handoff for the done feature
-	handoffDir := filepath.Join(dir, ".docket", "handoff")
-	os.MkdirAll(handoffDir, 0755)
-	os.WriteFile(filepath.Join(handoffDir, "done-feature.md"), []byte("stale"), 0644)
-
-	// Stale handoff cleanup happens on re-trigger
-	h := &hookInput{
-		SessionID:      "test-session",
-		CWD:            dir,
-		HookEventName:  "Stop",
-		StopHookActive: true,
-	}
-
-	var buf bytes.Buffer
-	handleStop(h, &buf)
-
-	// Active feature should have a handoff
-	if _, err := os.Stat(filepath.Join(handoffDir, "active-feature.md")); err != nil {
-		t.Error("active handoff should exist")
-	}
-	// Done feature handoff should be cleaned up
-	if _, err := os.Stat(filepath.Join(handoffDir, "done-feature.md")); !os.IsNotExist(err) {
-		t.Error("stale handoff should be deleted")
 	}
 }
 
@@ -704,8 +633,8 @@ func TestIsPlanFile(t *testing.T) {
 		{"docs/superpowers/plans/2026-03-28-feature.md", true},
 		{"plans/my-plan.md", true},
 		{"docs/my-feature-plan.md", true},
-		{"src/plans/config.go", false},        // not .md
-		{"docs/migration-plans/notes.txt", false}, // not .md
+		{"src/plans/config.go", false},             // not .md
+		{"docs/migration-plans/notes.txt", false},  // not .md
 		{"src/handler.go", false},
 		{"README.md", false},
 		{"plans/readme.txt", false}, // not .md
@@ -988,5 +917,67 @@ func TestSessionStartClearsSentinel(t *testing.T) {
 	// Verify sentinel was cleared
 	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
 		t.Error("expected agent-nudged sentinel to be cleared on SessionStart")
+	}
+}
+
+func TestPreCompactEnqueuesCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := store.Open(dir)
+	s.AddFeature("Test Feature", "test")
+	s.UpdateFeature("test-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+	s.OpenWorkSession("test-feature", "sess-1")
+	os.WriteFile(filepath.Join(dir, ".docket", "transcript-offset"), []byte("0"), 0644)
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "sess-1",
+		CWD:           dir,
+		HookEventName: "PreCompact",
+		Trigger:       "auto",
+	}
+
+	var buf bytes.Buffer
+	handlePreCompact(h, &buf)
+
+	var out hookOutput
+	json.Unmarshal(buf.Bytes(), &out)
+	if !out.Continue {
+		t.Error("PreCompact must always continue")
+	}
+
+	// Should have enqueued a checkpoint job
+	s2, _ := store.Open(dir)
+	defer s2.Close()
+	job, err := s2.DequeueCheckpointJob()
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if job == nil {
+		t.Fatal("expected a checkpoint job to be enqueued")
+	}
+	if job.Reason != "precompact" {
+		t.Errorf("job.Reason = %q, want %q", job.Reason, "precompact")
+	}
+}
+
+func TestIsDeltaMeaningfulWithCommitsLog(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".docket"), 0755)
+	commitsPath := filepath.Join(dir, ".docket", "commits.log")
+	os.WriteFile(commitsPath, []byte("abc123|||fix bug\n"), 0644)
+
+	delta := &transcript.Delta{}
+	if !isDeltaMeaningful(dir, delta) {
+		t.Error("delta with commits.log should be meaningful")
+	}
+}
+
+func TestIsDeltaMeaningfulEmpty(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".docket"), 0755)
+
+	delta := &transcript.Delta{}
+	if isDeltaMeaningful(dir, delta) {
+		t.Error("empty delta should not be meaningful")
 	}
 }

--- a/cmd/docket/hook_test.go
+++ b/cmd/docket/hook_test.go
@@ -841,3 +841,94 @@ func TestPreToolUseNoFeatures(t *testing.T) {
 		t.Error("expected agent-nudged sentinel to be created")
 	}
 }
+
+func TestPreToolUseFeatureNoTaskItems(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := s.AddFeature("My Feature", "testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := "in_progress"
+	s.UpdateFeature(f.ID, store.FeatureUpdate{Status: &status})
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Agent",
+	}
+
+	var buf bytes.Buffer
+	handlePreToolUse(h, &buf)
+
+	var out preToolUseOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Error("expected permissionDecision=allow")
+	}
+	if !strings.Contains(out.SystemMessage, "no task items") {
+		t.Errorf("expected task items nudge, got: %s", out.SystemMessage)
+	}
+	if !strings.Contains(out.SystemMessage, f.ID) {
+		t.Errorf("expected feature ID in message, got: %s", out.SystemMessage)
+	}
+}
+
+func TestPreToolUseFeatureWithTaskItems(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := s.AddFeature("My Feature", "testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := "in_progress"
+	s.UpdateFeature(f.ID, store.FeatureUpdate{Status: &status})
+
+	// Add a subtask with a task item
+	st, err := s.AddSubtask(f.ID, "Task 1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.AddTaskItem(st.ID, "Step 1: do something", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Agent",
+	}
+
+	var buf bytes.Buffer
+	handlePreToolUse(h, &buf)
+
+	var out preToolUseOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Error("expected permissionDecision=allow")
+	}
+	if out.SystemMessage != "" {
+		t.Errorf("expected no systemMessage when task items exist, got: %s", out.SystemMessage)
+	}
+
+	// Verify no sentinel written
+	sentinel := filepath.Join(dir, ".docket", "agent-nudged")
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Error("sentinel should NOT be written when feature has task items")
+	}
+}

--- a/cmd/docket/hook_test.go
+++ b/cmd/docket/hook_test.go
@@ -932,3 +932,61 @@ func TestPreToolUseFeatureWithTaskItems(t *testing.T) {
 		t.Error("sentinel should NOT be written when feature has task items")
 	}
 }
+
+func TestPreToolUseSentinelPreventsReNudge(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// Write the sentinel (simulating a prior nudge)
+	sentinel := filepath.Join(dir, ".docket", "agent-nudged")
+	os.WriteFile(sentinel, []byte{}, 0644)
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Agent",
+	}
+
+	var buf bytes.Buffer
+	handlePreToolUse(h, &buf)
+
+	var out preToolUseOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if out.SystemMessage != "" {
+		t.Errorf("expected no nudge when sentinel exists, got: %s", out.SystemMessage)
+	}
+}
+
+func TestSessionStartClearsSentinel(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// Write a sentinel from a prior session
+	sentinel := filepath.Join(dir, ".docket", "agent-nudged")
+	os.WriteFile(sentinel, []byte{}, 0644)
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "SessionStart",
+	}
+
+	var buf bytes.Buffer
+	handleSessionStart(h, &buf)
+
+	// Verify sentinel was cleared
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Error("expected agent-nudged sentinel to be cleared on SessionStart")
+	}
+}

--- a/cmd/docket/hook_test.go
+++ b/cmd/docket/hook_test.go
@@ -659,6 +659,43 @@ func TestPostToolUseAutoImportsPlan(t *testing.T) {
 	}
 }
 
+func TestSessionStartAutoArchives(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a done feature backdated 8 days
+	s.AddFeature("Old Done Feature", "")
+	done := "done"
+	s.UpdateFeature("old-done-feature", store.FeatureUpdate{Status: &done})
+	s.DB().Exec(`UPDATE features SET updated_at = datetime('now', '-8 days') WHERE id = 'old-done-feature'`)
+
+	// Create an active feature
+	s.AddFeature("Active Feature", "")
+	ip := "in_progress"
+	s.UpdateFeature("active-feature", store.FeatureUpdate{Status: &ip})
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "SessionStart",
+	}
+
+	var buf bytes.Buffer
+	handleSessionStart(h, &buf)
+
+	// Verify old feature was archived
+	s2, _ := store.Open(dir)
+	defer s2.Close()
+	f, _ := s2.GetFeature("old-done-feature")
+	if f.Status != "archived" {
+		t.Fatalf("expected archived, got %q", f.Status)
+	}
+}
+
 func TestIsPlanFile(t *testing.T) {
 	tests := []struct {
 		path string

--- a/cmd/docket/hook_test.go
+++ b/cmd/docket/hook_test.go
@@ -802,3 +802,42 @@ func TestPostToolUseRecordsCommit(t *testing.T) {
 		t.Errorf("expected feature ID in message, got: %s", out.SystemMessage)
 	}
 }
+
+func TestPreToolUseNoFeatures(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Agent",
+	}
+
+	var buf bytes.Buffer
+	handlePreToolUse(h, &buf)
+
+	var out preToolUseOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Error("expected permissionDecision=allow")
+	}
+	if !strings.Contains(out.SystemMessage, "No active docket feature") {
+		t.Errorf("expected nudge message, got: %s", out.SystemMessage)
+	}
+	if !strings.Contains(out.SystemMessage, "get_ready") {
+		t.Errorf("expected get_ready instruction, got: %s", out.SystemMessage)
+	}
+
+	// Verify sentinel was written
+	sentinel := filepath.Join(dir, ".docket", "agent-nudged")
+	if _, err := os.Stat(sentinel); os.IsNotExist(err) {
+		t.Error("expected agent-nudged sentinel to be created")
+	}
+}

--- a/cmd/docket/main.go
+++ b/cmd/docket/main.go
@@ -96,7 +96,7 @@ func runServe() {
 	}()
 
 	// Run MCP server on stdio (blocks)
-	mcpServer := docketmcp.NewServer(s)
+	mcpServer := docketmcp.NewServer(s, dir)
 	if err := server.ServeStdio(mcpServer); err != nil {
 		log.Fatalf("mcp server: %v", err)
 	}

--- a/cmd/docket/main.go
+++ b/cmd/docket/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
@@ -9,10 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/mark3labs/mcp-go/server"
 
 	staticfiles "github.com/sniffle6/claude-docket/dashboard"
+	"github.com/sniffle6/claude-docket/internal/checkpoint"
 	"github.com/sniffle6/claude-docket/internal/dashboard"
 	docketmcp "github.com/sniffle6/claude-docket/internal/mcp"
 	"github.com/sniffle6/claude-docket/internal/store"
@@ -94,6 +97,23 @@ func runServe() {
 			log.Printf("dashboard error: %v", err)
 		}
 	}()
+
+	// Start checkpoint worker in background
+	cfg := checkpoint.LoadConfig()
+	var summarizer checkpoint.SummarizerBackend
+	if cfg.Enabled {
+		summarizer = checkpoint.NewAnthropicSummarizer(cfg)
+		log.Printf("Checkpoint summarizer: enabled (model: %s)", cfg.Model)
+	} else {
+		summarizer = &checkpoint.NoopSummarizer{}
+		log.Printf("Checkpoint summarizer: disabled (no ANTHROPIC_API_KEY)")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	worker := checkpoint.NewWorker(s, summarizer)
+	go worker.Run(ctx, 5*time.Second)
 
 	// Run MCP server on stdio (blocks)
 	mcpServer := docketmcp.NewServer(s, dir)

--- a/cmd/docket/update.go
+++ b/cmd/docket/update.go
@@ -16,8 +16,12 @@ This project uses ` + "`docket`" + ` for feature tracking. Dashboard: http://loc
 
 Start of work (after any brainstorming/planning) — call ` + "`get_ready`" + ` to find existing features, then dispatch ` + "`board-manager`" + ` agent (model: sonnet) to create or find a card. Use ` + "`type`" + ` param (feature/bugfix/chore/spike) to auto-generate subtask templates.
 
+Use ` + "`tags`" + ` param (comma-separated) on ` + "`add_feature`" + `/` + "`update_feature`" + ` to categorize work. New tags warn about existing tags to prevent typos.
+
+Done features are auto-archived after 7 days. Use ` + "`list_features(status=\"archived\")`" + ` to see them. ` + "`update_feature(status=\"planned\")`" + ` to unarchive.
+
 After a commit — use **direct MCP calls**, not agent dispatch:
-- ` + "`update_feature`" + ` — set left_off, key_files, status. Completion gate blocks ` + "`done`" + ` with unchecked items — pass ` + "`force=true`" + ` + ` + "`force_reason`" + ` to override.
+- ` + "`update_feature`" + ` — set left_off, key_files, status, tags. Completion gate blocks ` + "`done`" + ` with unchecked items — pass ` + "`force=true`" + ` + ` + "`force_reason`" + ` to override.
 - ` + "`complete_task_item`" + ` — check off items with outcome and commit_hash (pass ` + "`items`" + ` JSON array for batch)
 - ` + "`add_decision`" + ` — record notable decisions (accepted/rejected with reason)
 - ` + "`add_issue`" + ` / ` + "`resolve_issue`" + ` — track bugs found during work

--- a/cmd/docket/update.go
+++ b/cmd/docket/update.go
@@ -38,7 +38,7 @@ After subagent work — subagent commits bypass hooks. Use direct MCP calls to b
 
 Use ` + "`get_context`" + ` (not ` + "`get_feature`" + `) for routine status checks — it's token-efficient (~15 lines).
 
-Session logging and handoff files are handled automatically by the Stop hook.
+Session context is captured automatically via transcript checkpoints (Stop/PreCompact hooks). Handoff files are written at SessionEnd. Use ` + "`/checkpoint`" + ` to force a manual checkpoint, ` + "`/end-session`" + ` to close the work session without closing Claude.
 
 Carry the feature ID across the session.
 

--- a/cmd/docket/update.go
+++ b/cmd/docket/update.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const docketSection = `## Feature Tracking (docket)
+const docketSectionHead = `## Feature Tracking (docket)
 
 This project uses ` + "`docket`" + ` for feature tracking. Dashboard: http://localhost:<port> (or run ` + "`/docket`" + `).
 
@@ -19,7 +19,13 @@ Start of work (after any brainstorming/planning) — call ` + "`get_ready`" + ` 
 Use ` + "`tags`" + ` param (comma-separated) on ` + "`add_feature`" + `/` + "`update_feature`" + ` to categorize work. New tags warn about existing tags to prevent typos.
 
 Done features are auto-archived after 7 days. Use ` + "`list_features(status=\"archived\")`" + ` to see them. ` + "`update_feature(status=\"planned\")`" + ` to unarchive.
+`
 
+const docketSectionSuperpowers = `
+**Plan execution (superpowers):** When using executing-plans or subagent-driven-development, set up docket BEFORE dispatching the first task — call ` + "`get_ready`" + `, create/find a feature card, and use ` + "`add_task_item`" + ` for each plan task. A PreToolUse hook will remind you if you forget.
+`
+
+const docketSectionTail = `
 After a commit — use **direct MCP calls**, not agent dispatch:
 - ` + "`update_feature`" + ` — set left_off, key_files, status, tags. Completion gate blocks ` + "`done`" + ` with unchecked items — pass ` + "`force=true`" + ` + ` + "`force_reason`" + ` to override.
 - ` + "`complete_task_item`" + ` — check off items with outcome and commit_hash (pass ` + "`items`" + ` JSON array for batch)
@@ -41,6 +47,25 @@ Carry the feature ID across the session.
 
 const sectionHeading = "## Feature Tracking (docket)"
 
+func buildDocketSection(hasSuperpowers bool) string {
+	if hasSuperpowers {
+		return docketSectionHead + docketSectionSuperpowers + docketSectionTail
+	}
+	return docketSectionHead + docketSectionTail
+}
+
+func detectSuperpowers() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	data, err := os.ReadFile(home + "/.claude/plugins/installed_plugins.json")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "superpowers")
+}
+
 func runUpdate() {
 	data, err := os.ReadFile("CLAUDE.md")
 	if err != nil {
@@ -49,7 +74,8 @@ func runUpdate() {
 	}
 
 	content := string(data)
-	updated := updateDocketSection(content)
+	section := buildDocketSection(detectSuperpowers())
+	updated := updateDocketSection(content, section)
 
 	if updated == content {
 		fmt.Println("CLAUDE.md docket section is already up to date.")
@@ -63,7 +89,7 @@ func runUpdate() {
 	fmt.Println("Updated CLAUDE.md with latest docket section.")
 }
 
-func updateDocketSection(content string) string {
+func updateDocketSection(content string, section string) string {
 	// If section exists, replace it in place
 	idx := strings.Index(content, sectionHeading)
 	if idx >= 0 {
@@ -72,10 +98,10 @@ func updateDocketSection(content string) string {
 		endIdx := strings.Index(rest, "\n## ")
 		if endIdx >= 0 {
 			// Replace section, keep everything after
-			return content[:idx] + docketSection + "\n" + rest[endIdx+1:]
+			return content[:idx] + section + "\n" + rest[endIdx+1:]
 		}
 		// Section goes to EOF
-		return content[:idx] + docketSection
+		return content[:idx] + section
 	}
 
 	// Not found — insert after the first section
@@ -93,7 +119,7 @@ func updateDocketSection(content string) string {
 			}
 			// This is the second ## heading — insert before it
 			result = append(result, "")
-			result = append(result, strings.Split(strings.TrimRight(docketSection, "\n"), "\n")...)
+			result = append(result, strings.Split(strings.TrimRight(section, "\n"), "\n")...)
 			result = append(result, "")
 			inserted = true
 		}
@@ -104,7 +130,7 @@ func updateDocketSection(content string) string {
 	if !inserted {
 		// No second heading found — append at end
 		result = append(result, "")
-		result = append(result, strings.Split(strings.TrimRight(docketSection, "\n"), "\n")...)
+		result = append(result, strings.Split(strings.TrimRight(section, "\n"), "\n")...)
 		result = append(result, "")
 	}
 

--- a/cmd/docket/update_test.go
+++ b/cmd/docket/update_test.go
@@ -19,7 +19,7 @@ Old line 2.
 go build
 ` + "```" + `
 `
-	result := updateDocketSection(input)
+	result := updateDocketSection(input, buildDocketSection(false))
 
 	if !strings.Contains(result, "direct MCP calls") {
 		t.Error("expected new snippet content")
@@ -43,7 +43,7 @@ Build instructions here.
 
 Test instructions here.
 `
-	result := updateDocketSection(input)
+	result := updateDocketSection(input, buildDocketSection(false))
 
 	buildIdx := strings.Index(result, "## Build")
 	docketIdx := strings.Index(result, "## Feature Tracking (docket)")
@@ -67,7 +67,7 @@ func TestUpdateDocketSectionAppendsWhenNoSecondHeading(t *testing.T) {
 
 This is the only section.
 `
-	result := updateDocketSection(input)
+	result := updateDocketSection(input, buildDocketSection(false))
 
 	if !strings.Contains(result, "## Feature Tracking (docket)") {
 		t.Error("docket section not inserted")
@@ -81,8 +81,9 @@ This is the only section.
 
 func TestUpdateDocketSectionAlreadyUpToDate(t *testing.T) {
 	// Build content that already has the current snippet
-	input := "# My Project\n\n" + docketSection + "\n## Build\n"
-	result := updateDocketSection(input)
+	section := buildDocketSection(false)
+	input := "# My Project\n\n" + section + "\n## Build\n"
+	result := updateDocketSection(input, section)
 
 	if result != input {
 		t.Error("should not change content that's already up to date")
@@ -100,7 +101,7 @@ Build stuff.
 
 Old content at the end of file.`
 
-	result := updateDocketSection(input)
+	result := updateDocketSection(input, buildDocketSection(false))
 
 	if !strings.Contains(result, "direct MCP calls") {
 		t.Error("expected new snippet content")
@@ -110,5 +111,33 @@ Old content at the end of file.`
 	}
 	if !strings.Contains(result, "## Build") {
 		t.Error("Build section should be preserved")
+	}
+}
+
+func TestBuildDocketSectionWithSuperpowers(t *testing.T) {
+	result := buildDocketSection(true)
+
+	if !strings.Contains(result, "Plan execution (superpowers)") {
+		t.Error("expected superpowers paragraph")
+	}
+	if !strings.Contains(result, "direct MCP calls") {
+		t.Error("expected tail content")
+	}
+	if !strings.Contains(result, "## Feature Tracking (docket)") {
+		t.Error("expected section heading")
+	}
+}
+
+func TestBuildDocketSectionWithoutSuperpowers(t *testing.T) {
+	result := buildDocketSection(false)
+
+	if strings.Contains(result, "Plan execution (superpowers)") {
+		t.Error("should not include superpowers paragraph")
+	}
+	if !strings.Contains(result, "direct MCP calls") {
+		t.Error("expected tail content")
+	}
+	if !strings.Contains(result, "## Feature Tracking (docket)") {
+		t.Error("expected section heading")
 	}
 }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -208,9 +208,25 @@
   }
   html.light .issue-badge { background: #FFD0D0; color: #8A2020; }
 
+  .tag-pill {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    border: 1px solid #4ECDC440;
+    color: var(--teal);
+    margin: 2px 2px 2px 0;
+  }
+  html.light .tag-pill { border-color: #1A7A7240; color: #1A7A72; }
+
   /* Done cards dimmed */
   .col-done .card { opacity: 0.65; }
   .col-done .card:hover { opacity: 1; }
+
+  .col-archived .column-header { color: var(--muted); }
+  .col-archived .dot { background: var(--muted); }
+  .col-archived .card { opacity: 0.45; }
+  .col-archived .card:hover { opacity: 0.8; }
 
   /* Empty column hint */
   .empty-hint {
@@ -268,6 +284,8 @@
   .badge-blocked { background: #C73A3A20; color: var(--blocked); }
   .badge-dev_complete, .badge-dev-complete { background: #FFD16620; color: var(--yellow); }
   .badge-done { background: #95E06C20; color: var(--done); }
+  .badge-archived { background: #8A887810; color: var(--muted); }
+  html.light .badge-archived { background: #EAEAEA; color: var(--muted); }
 
   .type-badge {
     padding: 2px 8px;
@@ -515,6 +533,7 @@
 <header>
   <div style="display:flex;align-items:center;gap:10px"><img src="docket-logo.png" alt="docket" height="32" style="width:auto"><h1>docket <span id="projectName" style="color:var(--muted);font-weight:400;font-size:16px;"></span></h1></div>
   <div class="header-right">
+    <button class="theme-toggle" id="archiveToggle" onclick="toggleArchived()" title="Show archived features" style="font-size:13px">&#x1F4E6;</button>
     <span class="unlinked-badge" id="unlinkedBadge" onclick="showUnlinked()">0 unlinked sessions</span>
     <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" title="Toggle dark/light mode"></button>
   </div>
@@ -535,19 +554,31 @@ function toggleTheme() {
   localStorage.setItem('docket-theme', isLight ? 'light' : 'dark');
   document.getElementById('themeToggle').textContent = isLight ? '\u2600' : '\u263E';
 }
+function toggleArchived() {
+  showArchived = !showArchived;
+  document.getElementById('archiveToggle').style.borderColor = showArchived ? 'var(--primary)' : '';
+  load();
+}
 initTheme();
 
 var API = '';
 var STATUSES = ['planned', 'in_progress', 'blocked', 'dev_complete', 'done'];
-var STATUS_LABELS = { planned: 'Planned', in_progress: 'In Progress', blocked: 'Blocked', dev_complete: 'Dev Complete', done: 'Done' };
-var STATUS_CSS = { planned: 'col-planned', in_progress: 'col-in-progress', blocked: 'col-blocked', dev_complete: 'col-dev-complete', done: 'col-done' };
+var ALL_STATUSES = ['planned', 'in_progress', 'blocked', 'dev_complete', 'done', 'archived'];
+var STATUS_LABELS = { planned: 'Planned', in_progress: 'In Progress', blocked: 'Blocked', dev_complete: 'Dev Complete', done: 'Done', archived: 'Archived' };
+var STATUS_CSS = { planned: 'col-planned', in_progress: 'col-in-progress', blocked: 'col-blocked', dev_complete: 'col-dev-complete', done: 'col-done', archived: 'col-archived' };
 var features = [];
 var currentPanelId = null;
+var showArchived = false;
 
 async function load() {
   try {
     var res = await fetch(API + '/api/features');
     features = await res.json();
+    if (showArchived) {
+      var res2 = await fetch(API + '/api/features?status=archived');
+      var archived = await res2.json();
+      features = features.concat(archived);
+    }
   } catch(e) { features = []; }
   render();
   loadUnlinked();
@@ -556,8 +587,10 @@ async function load() {
 function render() {
   var board = document.getElementById('board');
   board.innerHTML = '';
-  for (var si = 0; si < STATUSES.length; si++) {
-    var status = STATUSES[si];
+  var statuses = showArchived ? ALL_STATUSES : STATUSES;
+  board.style.gridTemplateColumns = 'repeat(' + statuses.length + ', 1fr)';
+  for (var si = 0; si < statuses.length; si++) {
+    var status = statuses[si];
     var col = document.createElement('div');
     col.className = 'column ' + STATUS_CSS[status];
     var items = features.filter(function(f) { return f.status === status; });
@@ -643,6 +676,20 @@ function render() {
         card.appendChild(issueBadge);
       }
 
+      // Tag pills
+      var tags = f.tags || [];
+      if (tags.length > 0) {
+        var tagWrap = document.createElement('div');
+        tagWrap.style.marginTop = '6px';
+        for (var ti = 0; ti < tags.length; ti++) {
+          var pill = document.createElement('span');
+          pill.className = 'tag-pill';
+          pill.textContent = tags[ti];
+          tagWrap.appendChild(pill);
+        }
+        card.appendChild(tagWrap);
+      }
+
       col.appendChild(card);
     }
     board.appendChild(col);
@@ -689,6 +736,15 @@ async function showDetail(id) {
     typeBadge.className = 'type-badge';
     typeBadge.textContent = f.type;
     slugDiv.appendChild(typeBadge);
+  }
+  if (f.tags && f.tags.length > 0) {
+    for (var ti = 0; ti < f.tags.length; ti++) {
+      var tagPill = document.createElement('span');
+      tagPill.className = 'tag-pill';
+      tagPill.style.marginLeft = '6px';
+      tagPill.textContent = f.tags[ti];
+      slugDiv.appendChild(tagPill);
+    }
   }
   panel.appendChild(slugDiv);
 

--- a/docs/docket-hooks.md
+++ b/docs/docket-hooks.md
@@ -1,36 +1,67 @@
 # Docket Auto-Tracking Hooks
 
-Docket automatically tracks your session activity using Claude Code lifecycle hooks. No manual steps needed.
+Docket automatically tracks session activity using Claude Code lifecycle hooks and background checkpoint summarization.
 
 ## What it does
 
-- **Session start**: Injects active feature context (title, status, left_off, next task) into the conversation
-- **After git commits**: Records each commit hash and message to `.docket/commits.log`
-- **Session end (two-phase)**: Blocks Claude from stopping, prompts it to call `log_session` with a rich AI-generated summary (what was done, key decisions, dead ends, gotchas). On re-trigger, writes handoff files and cleans up.
+- **Session start**: Injects active feature context (title, status, left_off, next task) into the conversation. Opens a work session linking the Claude session to the active feature.
+- **After git commits**: Records each commit hash and message to `.docket/commits.log`.
+- **Stop (every turn)**: If meaningful delta exists (commits, errors, failed tests, or substantial text), enqueues a checkpoint job. Never blocks.
+- **PreCompact**: Forces a checkpoint before context compression — captures everything before the conversation shrinks.
+- **SessionEnd**: Enqueues final checkpoint, writes handoff files with "Last Session" section from accumulated observations, closes the work session.
 
 ## How it works
 
 The plugin declares hooks in `plugin/hooks/hooks.json`. Claude Code fires these automatically:
 
-1. `SessionStart` → runs `docket.exe hook` → outputs feature context as systemMessage
-2. `PostToolUse` (Bash only) → runs `docket.exe hook` → checks for `git commit`, appends to commits.log
-3. `Stop` (first, `stop_hook_active=false`) → if active feature + commits, returns `decision: "block"` with a `reason` prompting Claude to call `log_session` with a rich summary and `update_feature` to set `left_off`
-4. `Stop` (re-trigger, `stop_hook_active=true`) → writes handoff files, cleans up commits.log, allows stop
+1. `SessionStart` → opens work session, resets transcript offset, injects feature context
+2. `PostToolUse` (Bash only) → detects `git commit`, appends to commits.log, auto-imports plan files
+3. `PreToolUse` (Agent only) → reminds to set up docket tracking before dispatching subagents
+4. `Stop` → parses transcript delta since last checkpoint, enqueues checkpoint job if meaningful, always allows stop
+5. `PreCompact` → forces a checkpoint (always enqueues, no threshold check)
+6. `SessionEnd` → enqueues final delta, writes handoff files, closes work session
 
-## Why two-phase stop?
+## Background summarizer
 
-The hook binary can't see the conversation — it only knows commit hashes and messages. By blocking the first stop attempt and prompting Claude via the `reason` field, the AI generates the summary using its full conversation context: what it worked on, what it tried that didn't work, key decisions, and gotchas. This produces far richer session logs than the old mechanical approach ("3 commit(s): feat: add X; fix: Y").
+A background worker in the MCP server process polls the `checkpoint_jobs` table and calls the Anthropic Messages API (haiku-tier) to generate structured observations:
+
+- **summary**: narrative of what happened
+- **blockers**: anything blocking progress
+- **dead_ends**: approaches that didn't work
+- **decisions**: choices made
+- **next_steps**: intent for next session
+- **gotchas**: non-obvious discoveries
+
+These observations are written to `checkpoint_observations` and rendered into the "Last Session" section of handoff files.
+
+Set `ANTHROPIC_API_KEY` to enable. Without it, the noop summarizer runs (only mechanical facts captured).
+
+## Meaningful delta threshold
+
+Stop only enqueues a checkpoint if at least one of:
+- commits.log has entries
+- Transcript contains commits or errors
+- Failed test runs detected
+- Semantic text >= 300 chars
+- Non-trivial user input
 
 ## Key files
 
-- `cmd/docket/hook.go` — hook subcommand logic (handleStop uses stopHookOutput with decision/reason)
+- `cmd/docket/hook.go` — hook subcommand logic (Stop, PreCompact, SessionEnd, SessionStart, PreToolUse, PostToolUse)
+- `cmd/docket/handoff.go` — handoff file renderer with Last Session section
+- `internal/checkpoint/worker.go` — background job queue worker
+- `internal/checkpoint/anthropic.go` — Anthropic Messages API summarizer
+- `internal/transcript/parse.go` — JSONL transcript parser
+- `internal/store/worksession.go` — work session store methods
+- `internal/store/checkpoint.go` — checkpoint job and observation store methods
 - `plugin/hooks/hooks.json` — hook declarations
-- `install.sh` — installs hooks and replaces binary path placeholder
+- `plugin/skills/checkpoint/SKILL.md` — /checkpoint skill
+- `plugin/skills/end-session/SKILL.md` — /end-session skill
 
 ## Gotchas
 
 - Hooks load at session start. After updating docket, restart Claude Code.
 - If a session crashes, stale `commits.log` may exist. SessionStart clears it.
-- Multiple in_progress features: all are listed, but next task is only shown for the first one.
-- The Stop hook only blocks when there's an active feature AND commits. Sessions with no commits pass through immediately.
-- The `stop_hook_active` field prevents infinite loops — the hook always allows stop on re-trigger.
+- Multiple in_progress features: all listed, but work session tracks the first one.
+- The summarizer has a 30-second timeout per job. Failures are logged and the job is marked failed.
+- Transcript path must be provided by Claude Code for parsing to work. If missing, only commits.log-based detection runs.

--- a/docs/pretooluse-agent-nudge.md
+++ b/docs/pretooluse-agent-nudge.md
@@ -1,0 +1,31 @@
+# PreToolUse Agent Nudge
+
+Docket fires a PreToolUse hook whenever Claude dispatches a subagent via the Agent tool. If docket tracking isn't set up — no active feature or no task items on the active feature — it injects a one-time reminder into the conversation.
+
+## Why it exists
+
+Superpowers' plan execution skills (executing-plans, subagent-driven-development) are prescriptive — they tell Claude exactly what steps to follow. The CLAUDE.md docket instructions get ignored. This hook fires at the exact moment work is about to be dispatched, catching the gap.
+
+## How it works
+
+1. PreToolUse fires on `Agent` tool
+2. Checks `.docket/` exists (skips if not a docket project)
+3. Checks for `.docket/agent-nudged` sentinel (skips if already nudged)
+4. Opens store, checks for in_progress features
+5. If no features -> nudge to call `get_ready`
+6. If feature exists but zero task items -> nudge to add task items
+7. If feature has task items -> silent pass-through
+8. Writes sentinel after nudging (one nudge per session)
+
+The sentinel is cleared on SessionStart, so each new session gets a fresh check.
+
+## Superpowers detection
+
+When `docket.exe update` runs, it checks `~/.claude/plugins/installed_plugins.json` for superpowers. If found, the CLAUDE.md snippet includes an extra paragraph about setting up docket before plan execution.
+
+## Key files
+
+- `cmd/docket/hook.go` — `handlePreToolUse` function, sentinel logic
+- `plugin/hooks/hooks.json` — PreToolUse matcher for Agent
+- `cmd/docket/update.go` — `buildDocketSection`, `detectSuperpowers`
+- `cmd/docket/hook_test.go` — PreToolUse test cases

--- a/docs/superpowers/plans/2026-03-29-pretooluse-agent-nudge.md
+++ b/docs/superpowers/plans/2026-03-29-pretooluse-agent-nudge.md
@@ -1,0 +1,734 @@
+# PreToolUse Agent Nudge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a PreToolUse hook on the Agent tool that nudges Claude to set up docket tracking before dispatching subagents, plus a conditional CLAUDE.md snippet paragraph for superpowers users.
+
+**Architecture:** New `handlePreToolUse` function in hook.go checks docket state (features, task items) and returns an informational systemMessage. Sentinel file prevents repeat nudges. update.go detects superpowers installation and conditionally includes a plan-execution paragraph.
+
+**Tech Stack:** Go, SQLite (existing store), JSON hook I/O
+
+---
+
+### Task 1: Add PreToolUse handler — no features case
+
+**Files:**
+- Modify: `cmd/docket/hook.go:14-36` (add new output struct)
+- Modify: `cmd/docket/hook.go:38-67` (add case to switch)
+- Modify: `cmd/docket/hook.go:69-100` (add sentinel clear in SessionStart)
+- Test: `cmd/docket/hook_test.go`
+
+- [ ] **Step 1: Write the failing test for PreToolUse with no features**
+
+Add to `cmd/docket/hook_test.go`:
+
+```go
+func TestPreToolUseNoFeatures(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Agent",
+	}
+
+	var buf bytes.Buffer
+	handlePreToolUse(h, &buf)
+
+	var out preToolUseOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Error("expected permissionDecision=allow")
+	}
+	if !strings.Contains(out.SystemMessage, "No active docket feature") {
+		t.Errorf("expected nudge message, got: %s", out.SystemMessage)
+	}
+	if !strings.Contains(out.SystemMessage, "get_ready") {
+		t.Errorf("expected get_ready instruction, got: %s", out.SystemMessage)
+	}
+
+	// Verify sentinel was written
+	sentinel := filepath.Join(dir, ".docket", "agent-nudged")
+	if _, err := os.Stat(sentinel); os.IsNotExist(err) {
+		t.Error("expected agent-nudged sentinel to be created")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -run TestPreToolUseNoFeatures -v`
+Expected: FAIL — `handlePreToolUse` undefined, `preToolUseOutput` undefined
+
+- [ ] **Step 3: Add the preToolUseOutput struct and handlePreToolUse function**
+
+In `cmd/docket/hook.go`, add the new output struct after the existing `stopHookOutput` struct (after line 36):
+
+```go
+type preToolUseOutput struct {
+	HookSpecificOutput *preToolUseDecision `json:"hookSpecificOutput,omitempty"`
+	SystemMessage      string              `json:"systemMessage,omitempty"`
+}
+
+type preToolUseDecision struct {
+	PermissionDecision string `json:"permissionDecision"`
+}
+```
+
+Add the `"PreToolUse"` case in the switch statement in `runHook` (after the `"SessionStart"` case):
+
+```go
+case "PreToolUse":
+	handlePreToolUse(&h, os.Stdout)
+```
+
+Add the handler function:
+
+```go
+func handlePreToolUse(h *hookInput, w io.Writer) {
+	allow := preToolUseOutput{
+		HookSpecificOutput: &preToolUseDecision{PermissionDecision: "allow"},
+	}
+
+	// Check sentinel — already nudged this session
+	sentinelPath := filepath.Join(h.CWD, ".docket", "agent-nudged")
+	if _, err := os.Stat(sentinelPath); err == nil {
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	s, err := store.Open(h.CWD)
+	if err != nil {
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+	defer s.Close()
+
+	features, err := s.ListFeatures("in_progress")
+	if err != nil {
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	if len(features) == 0 {
+		os.WriteFile(sentinelPath, []byte{}, 0644)
+		allow.SystemMessage = "[docket] No active docket feature. Call get_ready to set up tracking before dispatching subagents."
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	// Check if top feature has task items
+	_, total, err := s.GetFeatureProgress(features[0].ID)
+	if err != nil {
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	if total == 0 {
+		os.WriteFile(sentinelPath, []byte{}, 0644)
+		allow.SystemMessage = fmt.Sprintf(
+			"[docket] Active feature %q (id: %s) has no task items. Add task items from the plan before dispatching subagents.",
+			features[0].Title, features[0].ID,
+		)
+		json.NewEncoder(w).Encode(allow)
+		return
+	}
+
+	// Feature has task items — all good
+	json.NewEncoder(w).Encode(allow)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -run TestPreToolUseNoFeatures -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "H:\claude code\tools\docket"
+git add cmd/docket/hook.go cmd/docket/hook_test.go
+git commit -m "feat: add PreToolUse handler — nudge when no active features"
+```
+
+---
+
+### Task 2: Add PreToolUse handler — feature exists, no task items
+
+**Files:**
+- Test: `cmd/docket/hook_test.go`
+
+- [ ] **Step 1: Write the failing test for feature with no task items**
+
+Add to `cmd/docket/hook_test.go`:
+
+```go
+func TestPreToolUseFeatureNoTaskItems(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := s.AddFeature("My Feature", "testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := "in_progress"
+	s.UpdateFeature(f.ID, store.FeatureUpdate{Status: &status})
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Agent",
+	}
+
+	var buf bytes.Buffer
+	handlePreToolUse(h, &buf)
+
+	var out preToolUseOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Error("expected permissionDecision=allow")
+	}
+	if !strings.Contains(out.SystemMessage, "no task items") {
+		t.Errorf("expected task items nudge, got: %s", out.SystemMessage)
+	}
+	if !strings.Contains(out.SystemMessage, f.ID) {
+		t.Errorf("expected feature ID in message, got: %s", out.SystemMessage)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+This test should already pass because the implementation in Task 1 handles this case. Run:
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -run TestPreToolUseFeatureNoTaskItems -v`
+Expected: PASS
+
+- [ ] **Step 3: Write test for feature WITH task items (silent pass-through)**
+
+Add to `cmd/docket/hook_test.go`:
+
+```go
+func TestPreToolUseFeatureWithTaskItems(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := s.AddFeature("My Feature", "testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := "in_progress"
+	s.UpdateFeature(f.ID, store.FeatureUpdate{Status: &status})
+
+	// Add a subtask with a task item
+	st, err := s.AddSubtask(f.ID, "Task 1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.AddTaskItem(st.ID, "Step 1: do something", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Agent",
+	}
+
+	var buf bytes.Buffer
+	handlePreToolUse(h, &buf)
+
+	var out preToolUseOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if out.HookSpecificOutput == nil || out.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Error("expected permissionDecision=allow")
+	}
+	if out.SystemMessage != "" {
+		t.Errorf("expected no systemMessage when task items exist, got: %s", out.SystemMessage)
+	}
+
+	// Verify no sentinel written
+	sentinel := filepath.Join(dir, ".docket", "agent-nudged")
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Error("sentinel should NOT be written when feature has task items")
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -run TestPreToolUseFeatureWithTaskItems -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "H:\claude code\tools\docket"
+git add cmd/docket/hook_test.go
+git commit -m "test: add PreToolUse tests for task items and silent pass-through"
+```
+
+---
+
+### Task 3: Add sentinel nudge-once behavior and SessionStart cleanup
+
+**Files:**
+- Modify: `cmd/docket/hook.go:69-100` (handleSessionStart)
+- Test: `cmd/docket/hook_test.go`
+
+- [ ] **Step 1: Write the failing test for sentinel preventing re-nudge**
+
+Add to `cmd/docket/hook_test.go`:
+
+```go
+func TestPreToolUseSentinelPreventsReNudge(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// Write the sentinel (simulating a prior nudge)
+	sentinel := filepath.Join(dir, ".docket", "agent-nudged")
+	os.WriteFile(sentinel, []byte{}, 0644)
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "PreToolUse",
+		ToolName:      "Agent",
+	}
+
+	var buf bytes.Buffer
+	handlePreToolUse(h, &buf)
+
+	var out preToolUseOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if out.SystemMessage != "" {
+		t.Errorf("expected no nudge when sentinel exists, got: %s", out.SystemMessage)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+This should already pass because the sentinel check is in Task 1's implementation. Run:
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -run TestPreToolUseSentinelPreventsReNudge -v`
+Expected: PASS
+
+- [ ] **Step 3: Write the failing test for SessionStart clearing the sentinel**
+
+Add to `cmd/docket/hook_test.go`:
+
+```go
+func TestSessionStartClearsSentinel(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// Write a sentinel from a prior session
+	sentinel := filepath.Join(dir, ".docket", "agent-nudged")
+	os.WriteFile(sentinel, []byte{}, 0644)
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "SessionStart",
+	}
+
+	var buf bytes.Buffer
+	handleSessionStart(h, &buf)
+
+	// Verify sentinel was cleared
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Error("expected agent-nudged sentinel to be cleared on SessionStart")
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -run TestSessionStartClearsSentinel -v`
+Expected: FAIL — sentinel still exists after SessionStart
+
+- [ ] **Step 5: Add sentinel cleanup to handleSessionStart**
+
+In `cmd/docket/hook.go`, in `handleSessionStart`, add after the `commits.log` clear (after line ~87):
+
+```go
+// Clear agent-nudged sentinel
+os.Remove(filepath.Join(h.CWD, ".docket", "agent-nudged"))
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -run TestSessionStartClearsSentinel -v`
+Expected: PASS
+
+- [ ] **Step 7: Run all hook tests**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd "H:\claude code\tools\docket"
+git add cmd/docket/hook.go cmd/docket/hook_test.go
+git commit -m "feat: sentinel nudge-once and SessionStart cleanup for PreToolUse"
+```
+
+---
+
+### Task 4: Update hooks.json with PreToolUse matcher
+
+**Files:**
+- Modify: `plugin/hooks/hooks.json`
+
+- [ ] **Step 1: Add PreToolUse entry to hooks.json**
+
+In `plugin/hooks/hooks.json`, add the PreToolUse entry inside the `"hooks"` object (after the SessionStart block, before PostToolUse):
+
+```json
+"PreToolUse": [
+  {
+    "matcher": "Agent",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "DOCKET_EXE_PATH hook",
+        "timeout": 5
+      }
+    ]
+  }
+],
+```
+
+The `DOCKET_EXE_PATH` placeholder is replaced by `install.sh` during installation (line 74 of install.sh).
+
+- [ ] **Step 2: Verify JSON is valid**
+
+Run: `cd "H:\claude code\tools\docket" && python3 -c "import json; json.load(open('plugin/hooks/hooks.json')); print('Valid JSON')"`
+Expected: `Valid JSON`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "H:\claude code\tools\docket"
+git add plugin/hooks/hooks.json
+git commit -m "feat: add PreToolUse Agent matcher to hooks.json"
+```
+
+---
+
+### Task 5: Conditional superpowers paragraph in update.go
+
+**Files:**
+- Modify: `cmd/docket/update.go`
+- Test: `cmd/docket/update_test.go`
+
+- [ ] **Step 1: Write the failing test for superpowers detection**
+
+Add to `cmd/docket/update_test.go`:
+
+```go
+func TestBuildDocketSectionWithSuperpowers(t *testing.T) {
+	result := buildDocketSection(true)
+	if !strings.Contains(result, "Plan execution (superpowers)") {
+		t.Error("expected superpowers paragraph when detected")
+	}
+	if !strings.Contains(result, "executing-plans") {
+		t.Error("expected executing-plans mention")
+	}
+}
+
+func TestBuildDocketSectionWithoutSuperpowers(t *testing.T) {
+	result := buildDocketSection(false)
+	if strings.Contains(result, "Plan execution (superpowers)") {
+		t.Error("should not include superpowers paragraph when not detected")
+	}
+	// Should still have core docket content
+	if !strings.Contains(result, "Feature Tracking (docket)") {
+		t.Error("missing core docket section")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -run TestBuildDocketSection -v`
+Expected: FAIL — `buildDocketSection` undefined
+
+- [ ] **Step 3: Refactor update.go to split snippet and detect superpowers**
+
+Replace the `docketSection` const and `runUpdate` function in `cmd/docket/update.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const docketSectionHead = `## Feature Tracking (docket)
+
+This project uses ` + "`docket`" + ` for feature tracking. Dashboard: http://localhost:<port> (or run ` + "`/docket`" + `).
+
+**Small tasks** (cosmetic changes, one-off fixes, config tweaks): call ` + "`quick_track`" + ` directly — one call, no agent dispatch needed.
+
+**Larger features** (multi-step, plan-driven, complex):
+
+Start of work (after any brainstorming/planning) — call ` + "`get_ready`" + ` to find existing features, then dispatch ` + "`board-manager`" + ` agent (model: sonnet) to create or find a card. Use ` + "`type`" + ` param (feature/bugfix/chore/spike) to auto-generate subtask templates.
+
+Use ` + "`tags`" + ` param (comma-separated) on ` + "`add_feature`" + `/` + "`update_feature`" + ` to categorize work. New tags warn about existing tags to prevent typos.
+
+Done features are auto-archived after 7 days. Use ` + "`list_features(status=\"archived\")`" + ` to see them. ` + "`update_feature(status=\"planned\")`" + ` to unarchive.
+`
+
+const docketSectionSuperpowers = `
+**Plan execution (superpowers):** When using executing-plans or subagent-driven-development, set up docket BEFORE dispatching the first task — call ` + "`get_ready`" + `, create/find a feature card, and use ` + "`add_task_item`" + ` for each plan task. A PreToolUse hook will remind you if you forget.
+`
+
+const docketSectionTail = `
+After a commit — use **direct MCP calls**, not agent dispatch:
+- ` + "`update_feature`" + ` — set left_off, key_files, status, tags. Completion gate blocks ` + "`done`" + ` with unchecked items — pass ` + "`force=true`" + ` + ` + "`force_reason`" + ` to override.
+- ` + "`complete_task_item`" + ` — check off items with outcome and commit_hash (pass ` + "`items`" + ` JSON array for batch)
+- ` + "`add_decision`" + ` — record notable decisions (accepted/rejected with reason)
+- ` + "`add_issue`" + ` / ` + "`resolve_issue`" + ` — track bugs found during work
+
+Plan files committed during work are auto-imported by hooks. Only dispatch board-manager when the update needs judgment (restructuring imported plans, creating new subtasks).
+
+After subagent work — subagent commits bypass hooks. Use direct MCP calls to batch-update the feature.
+
+Use ` + "`get_context`" + ` (not ` + "`get_feature`" + `) for routine status checks — it's token-efficient (~15 lines).
+
+Session logging and handoff files are handled automatically by the Stop hook.
+
+Carry the feature ID across the session.
+
+**If user rejects a docket update**, fix the issue and retry — don't drop tracking.
+`
+
+const sectionHeading = "## Feature Tracking (docket)"
+
+func buildDocketSection(hasSuperpowers bool) string {
+	if hasSuperpowers {
+		return docketSectionHead + docketSectionSuperpowers + docketSectionTail
+	}
+	return docketSectionHead + docketSectionTail
+}
+
+func detectSuperpowers() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	pluginsFile := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
+	data, err := os.ReadFile(pluginsFile)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "superpowers")
+}
+
+func runUpdate() {
+	data, err := os.ReadFile("CLAUDE.md")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "No CLAUDE.md found in current directory.")
+		os.Exit(1)
+	}
+
+	content := string(data)
+	docketSection := buildDocketSection(detectSuperpowers())
+	updated := updateDocketSection(content, docketSection)
+
+	if updated == content {
+		fmt.Println("CLAUDE.md docket section is already up to date.")
+		return
+	}
+
+	if err := os.WriteFile("CLAUDE.md", []byte(updated), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write CLAUDE.md: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Updated CLAUDE.md with latest docket section.")
+}
+
+func updateDocketSection(content, docketSection string) string {
+	// If section exists, replace it in place
+	idx := strings.Index(content, sectionHeading)
+	if idx >= 0 {
+		// Find the end of this section (next ## heading or EOF)
+		rest := content[idx+len(sectionHeading):]
+		endIdx := strings.Index(rest, "\n## ")
+		if endIdx >= 0 {
+			// Replace section, keep everything after
+			return content[:idx] + docketSection + "\n" + rest[endIdx+1:]
+		}
+		// Section goes to EOF
+		return content[:idx] + docketSection
+	}
+
+	// Not found — insert after the first section
+	lines := strings.Split(content, "\n")
+	var result []string
+	inserted := false
+	passedFirstHeading := false
+
+	for i, line := range lines {
+		if !inserted && strings.HasPrefix(line, "## ") {
+			if !passedFirstHeading {
+				passedFirstHeading = true
+				result = append(result, line)
+				continue
+			}
+			// This is the second ## heading — insert before it
+			result = append(result, "")
+			result = append(result, strings.Split(strings.TrimRight(docketSection, "\n"), "\n")...)
+			result = append(result, "")
+			inserted = true
+		}
+		result = append(result, line)
+		_ = i
+	}
+
+	if !inserted {
+		// No second heading found — append at end
+		result = append(result, "")
+		result = append(result, strings.Split(strings.TrimRight(docketSection, "\n"), "\n")...)
+		result = append(result, "")
+	}
+
+	return strings.Join(result, "\n")
+}
+```
+
+Note: `updateDocketSection` now takes the section content as a parameter instead of using the global const, so `buildDocketSection` controls what gets inserted.
+
+- [ ] **Step 4: Fix existing tests to use new signature**
+
+The existing tests in `update_test.go` call `updateDocketSection(input)` with one arg. Update them to pass `buildDocketSection(false)` as the second argument:
+
+Replace all calls of `updateDocketSection(input)` with `updateDocketSection(input, buildDocketSection(false))`.
+
+For `TestUpdateDocketSectionAlreadyUpToDate`, update the input construction to use `buildDocketSection(false)` instead of `docketSection`:
+
+```go
+func TestUpdateDocketSectionAlreadyUpToDate(t *testing.T) {
+	section := buildDocketSection(false)
+	input := "# My Project\n\n" + section + "\n## Build\n"
+	result := updateDocketSection(input, section)
+
+	if result != input {
+		t.Error("should not change content that's already up to date")
+	}
+}
+```
+
+- [ ] **Step 5: Run all tests to verify they pass**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./cmd/docket/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd "H:\claude code\tools\docket"
+git add cmd/docket/update.go cmd/docket/update_test.go
+git commit -m "feat: conditional superpowers paragraph in CLAUDE.md snippet"
+```
+
+---
+
+### Task 6: Run full test suite and update docs
+
+**Files:**
+- Modify: `docs/pretooluse-agent-nudge.md` (new doc)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd "H:\claude code\tools\docket" && go test ./... -v`
+Expected: All tests PASS
+
+- [ ] **Step 2: Build binary**
+
+Run: `cd "H:\claude code\tools\docket" && go build -ldflags="-s -w" -o docket.exe ./cmd/docket/`
+Expected: Builds without errors
+
+- [ ] **Step 3: Write feature doc**
+
+Create `docs/pretooluse-agent-nudge.md`:
+
+```markdown
+# PreToolUse Agent Nudge
+
+Docket fires a PreToolUse hook whenever Claude dispatches a subagent via the Agent tool. If docket tracking isn't set up — no active feature or no task items on the active feature — it injects a one-time reminder into the conversation.
+
+## Why it exists
+
+Superpowers' plan execution skills (executing-plans, subagent-driven-development) are prescriptive — they tell Claude exactly what steps to follow. The CLAUDE.md docket instructions get ignored. This hook fires at the exact moment work is about to be dispatched, catching the gap.
+
+## How it works
+
+1. PreToolUse fires on `Agent` tool
+2. Checks `.docket/` exists (skips if not a docket project)
+3. Checks for `.docket/agent-nudged` sentinel (skips if already nudged)
+4. Opens store, checks for in_progress features
+5. If no features → nudge to call `get_ready`
+6. If feature exists but zero task items → nudge to add task items
+7. If feature has task items → silent pass-through
+8. Writes sentinel after nudging (one nudge per session)
+
+The sentinel is cleared on SessionStart, so each new session gets a fresh check.
+
+## Superpowers detection
+
+When `docket.exe update` runs, it checks `~/.claude/plugins/installed_plugins.json` for superpowers. If found, the CLAUDE.md snippet includes an extra paragraph about setting up docket before plan execution.
+
+## Key files
+
+- `cmd/docket/hook.go` — `handlePreToolUse` function, sentinel logic
+- `plugin/hooks/hooks.json` — PreToolUse matcher for Agent
+- `cmd/docket/update.go` — `buildDocketSection`, `detectSuperpowers`
+- `cmd/docket/hook_test.go` — PreToolUse test cases
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "H:\claude code\tools\docket"
+git add docs/pretooluse-agent-nudge.md
+git commit -m "docs: PreToolUse agent nudge feature doc"
+```

--- a/docs/superpowers/plans/2026-03-29-tags-and-archival.md
+++ b/docs/superpowers/plans/2026-03-29-tags-and-archival.md
@@ -1,0 +1,1279 @@
+# Tags & Filtering + Feature Archival Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add free-form tags to features (with new-tag warnings) and an `archived` status with auto-archive of stale done features.
+
+**Architecture:** Tags stored as a JSON array column on `features` table (same pattern as `key_files`). Archival is a new status value — no new tables or columns. Auto-archive runs in the SessionStart hook. Dashboard gets tag pills on cards and an archived toggle.
+
+**Tech Stack:** Go, SQLite, vanilla JS (single-file dashboard)
+
+---
+
+### Task 1: Schema migration — add tags column
+
+**Files:**
+- Modify: `internal/store/migrate.go`
+
+- [ ] **Step 1: Add schemaV8 constant**
+
+```go
+const schemaV8 = `
+ALTER TABLE features ADD COLUMN tags TEXT NOT NULL DEFAULT '[]';
+`
+```
+
+Add this after the existing `schemaV7` constant.
+
+- [ ] **Step 2: Call schemaV8 in migrate()**
+
+Add this line after `db.Exec(schemaV7)`:
+
+```go
+// v8: add tags column to features (ignore error if already exists)
+db.Exec(schemaV8)
+```
+
+- [ ] **Step 3: Run tests to verify migration is safe**
+
+Run: `go test ./internal/store/ -run TestFeatureTypeField -v`
+Expected: PASS (existing tests still work — migration is additive)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/store/migrate.go
+git commit -m "feat: add schemaV8 — tags column on features table"
+```
+
+---
+
+### Task 2: Store layer — Tags on Feature structs and scan sites
+
+**Files:**
+- Modify: `internal/store/store.go`
+
+- [ ] **Step 1: Write failing test for tags roundtrip**
+
+Create `internal/store/tags_test.go`:
+
+```go
+package store
+
+import "testing"
+
+func TestFeatureTagsField(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	f, err := s.AddFeature("Tagged Feature", "desc")
+	if err != nil {
+		t.Fatalf("AddFeature: %v", err)
+	}
+	if len(f.Tags) != 0 {
+		t.Fatalf("expected empty tags, got %v", f.Tags)
+	}
+
+	tags := []string{"auth", "frontend"}
+	s.UpdateFeature(f.ID, FeatureUpdate{Tags: &tags})
+	f, _ = s.GetFeature(f.ID)
+	if len(f.Tags) != 2 || f.Tags[0] != "auth" || f.Tags[1] != "frontend" {
+		t.Fatalf("expected [auth frontend], got %v", f.Tags)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/store/ -run TestFeatureTagsField -v`
+Expected: FAIL — `Feature` struct has no `Tags` field
+
+- [ ] **Step 3: Add Tags field to Feature struct**
+
+In `store.go`, add to `Feature` struct after `KeyFiles`:
+
+```go
+Tags         []string  `json:"tags"`
+```
+
+Add to `FeatureUpdate` struct after `KeyFiles`:
+
+```go
+Tags         *[]string `json:"tags,omitempty"`
+```
+
+- [ ] **Step 4: Update GetFeature to scan tags**
+
+In `GetFeature`, update the SELECT to include `tags`:
+
+```go
+row := s.db.QueryRow(
+    `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE id = ?`,
+    id,
+)
+```
+
+Add a `tagsJSON` variable alongside `keyFilesJSON`:
+
+```go
+var keyFilesJSON, tagsJSON string
+err := row.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &tagsJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt)
+```
+
+After the `KeyFiles` unmarshal block, add:
+
+```go
+json.Unmarshal([]byte(tagsJSON), &f.Tags)
+if f.Tags == nil {
+    f.Tags = []string{}
+}
+```
+
+- [ ] **Step 5: Update ListFeatures to scan tags**
+
+Same pattern — add `tags` after `key_files` in the SELECT, add `tagsJSON` variable, scan it, unmarshal:
+
+```go
+query := `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features`
+```
+
+In the `rows.Next()` loop, change the scan to include `tagsJSON`:
+
+```go
+var keyFilesJSON, tagsJSON string
+if err := rows.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &tagsJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt); err != nil {
+```
+
+After keyFiles unmarshal:
+
+```go
+json.Unmarshal([]byte(tagsJSON), &f.Tags)
+if f.Tags == nil {
+    f.Tags = []string{}
+}
+```
+
+- [ ] **Step 6: Update GetReadyFeatures to scan tags**
+
+Same pattern as ListFeatures — add `tags` to SELECT, add `tagsJSON` to scan, unmarshal.
+
+The SELECT becomes:
+
+```go
+`SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE status IN ('in_progress', 'planned') ORDER BY CASE WHEN status='in_progress' THEN 0 ELSE 1 END, updated_at DESC`
+```
+
+Scan and unmarshal pattern identical to ListFeatures.
+
+- [ ] **Step 7: Add tags handling to UpdateFeature**
+
+After the `KeyFiles` block in `UpdateFeature`, add:
+
+```go
+if u.Tags != nil {
+    t, _ := json.Marshal(*u.Tags)
+    sets = append(sets, "tags = ?")
+    args = append(args, string(t))
+}
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `go test ./internal/store/ -run TestFeatureTagsField -v`
+Expected: PASS
+
+- [ ] **Step 9: Run all store tests to check nothing broke**
+
+Run: `go test ./internal/store/ -v`
+Expected: All PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/store/store.go internal/store/tags_test.go
+git commit -m "feat: add Tags field to Feature, update all scan sites"
+```
+
+---
+
+### Task 3: Store layer — tags in ListFeatures filter and tag utility methods
+
+**Files:**
+- Modify: `internal/store/store.go`
+- Modify: `internal/store/tags_test.go`
+
+- [ ] **Step 1: Write failing test for ListFeatures tag filter**
+
+Append to `internal/store/tags_test.go`:
+
+```go
+func TestFeatureTagsInList(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Auth Feature", "desc")
+	s.AddFeature("UI Feature", "desc")
+
+	authTags := []string{"auth", "backend"}
+	uiTags := []string{"frontend", "ui"}
+	s.UpdateFeature("auth-feature", FeatureUpdate{Tags: &authTags})
+	s.UpdateFeature("ui-feature", FeatureUpdate{Tags: &uiTags})
+
+	features, _ := s.ListFeatures("")
+	if len(features) != 2 {
+		t.Fatalf("expected 2 features, got %d", len(features))
+	}
+	if len(features[0].Tags) == 0 {
+		t.Fatal("expected tags in list results")
+	}
+}
+
+func TestListFeaturesFilterByTag(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Auth Feature", "")
+	s.AddFeature("UI Feature", "")
+	s.AddFeature("Mixed Feature", "")
+
+	authTags := []string{"auth"}
+	uiTags := []string{"ui"}
+	mixedTags := []string{"auth", "ui"}
+	s.UpdateFeature("auth-feature", FeatureUpdate{Tags: &authTags})
+	s.UpdateFeature("ui-feature", FeatureUpdate{Tags: &uiTags})
+	s.UpdateFeature("mixed-feature", FeatureUpdate{Tags: &mixedTags})
+
+	features, err := s.ListFeaturesWithTag("", "auth")
+	if err != nil {
+		t.Fatalf("ListFeaturesWithTag: %v", err)
+	}
+	if len(features) != 2 {
+		t.Fatalf("expected 2 features with auth tag, got %d", len(features))
+	}
+
+	// Combined with status filter
+	ip := "in_progress"
+	s.UpdateFeature("auth-feature", FeatureUpdate{Status: &ip})
+	features, _ = s.ListFeaturesWithTag("in_progress", "auth")
+	if len(features) != 1 || features[0].ID != "auth-feature" {
+		t.Fatalf("expected 1 in_progress feature with auth tag, got %d", len(features))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/store/ -run TestListFeaturesFilterByTag -v`
+Expected: FAIL — `ListFeaturesWithTag` undefined
+
+- [ ] **Step 3: Implement ListFeaturesWithTag**
+
+Add this method to `store.go` after `ListFeatures`:
+
+```go
+func (s *Store) ListFeaturesWithTag(status, tag string) ([]Feature, error) {
+	query := `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE tags LIKE ?`
+	args := []any{"%" + `"` + tag + `"` + "%"}
+	if status != "" {
+		query += " AND status = ?"
+		args = append(args, status)
+	}
+	query += " ORDER BY updated_at DESC"
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list features by tag: %w", err)
+	}
+	defer rows.Close()
+	var features []Feature
+	for rows.Next() {
+		var f Feature
+		var keyFilesJSON, tagsJSON string
+		if err := rows.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &tagsJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan feature: %w", err)
+		}
+		json.Unmarshal([]byte(keyFilesJSON), &f.KeyFiles)
+		if f.KeyFiles == nil {
+			f.KeyFiles = []string{}
+		}
+		json.Unmarshal([]byte(tagsJSON), &f.Tags)
+		if f.Tags == nil {
+			f.Tags = []string{}
+		}
+		features = append(features, f)
+	}
+	return features, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/store/ -run "TestFeatureTagsInList|TestListFeaturesFilterByTag" -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing tests for GetKnownTags and CheckNewTags**
+
+Append to `tags_test.go`:
+
+```go
+func TestGetKnownTags(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	// No features — no tags
+	tags, _ := s.GetKnownTags()
+	if len(tags) != 0 {
+		t.Fatalf("expected 0 tags, got %d", len(tags))
+	}
+
+	s.AddFeature("Feature A", "")
+	s.AddFeature("Feature B", "")
+	tagsA := []string{"backend", "auth"}
+	tagsB := []string{"auth", "frontend"}
+	s.UpdateFeature("feature-a", FeatureUpdate{Tags: &tagsA})
+	s.UpdateFeature("feature-b", FeatureUpdate{Tags: &tagsB})
+
+	tags, err := s.GetKnownTags()
+	if err != nil {
+		t.Fatalf("GetKnownTags: %v", err)
+	}
+	// Should be sorted and deduplicated: auth, backend, frontend
+	if len(tags) != 3 {
+		t.Fatalf("expected 3 unique tags, got %d: %v", len(tags), tags)
+	}
+	if tags[0] != "auth" || tags[1] != "backend" || tags[2] != "frontend" {
+		t.Fatalf("expected [auth backend frontend], got %v", tags)
+	}
+}
+
+func TestCheckNewTags(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Feature A", "")
+	existing := []string{"auth", "frontend"}
+	s.UpdateFeature("feature-a", FeatureUpdate{Tags: &existing})
+
+	// "auth" exists, "frntend" is new
+	newTags := s.CheckNewTags([]string{"auth", "frntend"})
+	if len(newTags) != 1 || newTags[0] != "frntend" {
+		t.Fatalf("expected [frntend], got %v", newTags)
+	}
+
+	// All existing — no new
+	newTags = s.CheckNewTags([]string{"auth", "frontend"})
+	if len(newTags) != 0 {
+		t.Fatalf("expected no new tags, got %v", newTags)
+	}
+}
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `go test ./internal/store/ -run "TestGetKnownTags|TestCheckNewTags" -v`
+Expected: FAIL — methods undefined
+
+- [ ] **Step 7: Implement GetKnownTags and CheckNewTags**
+
+Add to `store.go`:
+
+```go
+func (s *Store) GetKnownTags() ([]string, error) {
+	rows, err := s.db.Query(`SELECT tags FROM features WHERE tags != '[]'`)
+	if err != nil {
+		return nil, fmt.Errorf("get known tags: %w", err)
+	}
+	defer rows.Close()
+
+	seen := make(map[string]bool)
+	for rows.Next() {
+		var tagsJSON string
+		rows.Scan(&tagsJSON)
+		var tags []string
+		json.Unmarshal([]byte(tagsJSON), &tags)
+		for _, t := range tags {
+			seen[t] = true
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for t := range seen {
+		result = append(result, t)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func (s *Store) CheckNewTags(tags []string) []string {
+	known, _ := s.GetKnownTags()
+	knownSet := make(map[string]bool, len(known))
+	for _, t := range known {
+		knownSet[t] = true
+	}
+	var newTags []string
+	for _, t := range tags {
+		if !knownSet[t] {
+			newTags = append(newTags, t)
+		}
+	}
+	return newTags
+}
+```
+
+Add `"sort"` to the imports in `store.go`.
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `go test ./internal/store/ -run "TestGetKnownTags|TestCheckNewTags" -v`
+Expected: PASS
+
+- [ ] **Step 9: Write and run test for tags in UpdateFeature replacement**
+
+Append to `tags_test.go`:
+
+```go
+func TestTagsInUpdateFeature(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Replaceable", "")
+	tags1 := []string{"old", "stale"}
+	s.UpdateFeature("replaceable", FeatureUpdate{Tags: &tags1})
+
+	tags2 := []string{"new"}
+	s.UpdateFeature("replaceable", FeatureUpdate{Tags: &tags2})
+	f, _ := s.GetFeature("replaceable")
+	if len(f.Tags) != 1 || f.Tags[0] != "new" {
+		t.Fatalf("expected [new], got %v", f.Tags)
+	}
+}
+```
+
+Run: `go test ./internal/store/ -run TestTagsInUpdateFeature -v`
+Expected: PASS
+
+- [ ] **Step 10: Run full store test suite**
+
+Run: `go test ./internal/store/ -v`
+Expected: All PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add internal/store/store.go internal/store/tags_test.go
+git commit -m "feat: add ListFeaturesWithTag, GetKnownTags, CheckNewTags"
+```
+
+---
+
+### Task 4: MCP tool updates — tags param on add_feature, update_feature, list_features
+
+**Files:**
+- Modify: `internal/mcp/tools.go` — add `tags` param to tool definitions
+- Modify: `internal/mcp/tools_feature.go` — handler logic
+
+- [ ] **Step 1: Add tags param to add_feature tool definition**
+
+In `tools.go`, add after the `type` param on `add_feature`:
+
+```go
+mcp.WithString("tags", mcp.Description("Comma-separated tags (e.g., 'auth,frontend'). New tags trigger a warning listing existing tags.")),
+```
+
+- [ ] **Step 2: Add tags param to update_feature tool definition**
+
+In `tools.go`, add after the `key_files` param on `update_feature`:
+
+```go
+mcp.WithString("tags", mcp.Description("Comma-separated tags — replaces all existing tags. New tags trigger a warning.")),
+```
+
+- [ ] **Step 3: Add tag param to list_features tool definition**
+
+In `tools.go`, add after the `status` param on `list_features`:
+
+```go
+mcp.WithString("tag", mcp.Description("Filter to features with this tag. Combines with status filter.")),
+```
+
+- [ ] **Step 4: Update add_feature handler to handle tags and new-tag warnings**
+
+In `tools_feature.go`, in `addFeatureHandler`, after the `typ` handling block (the `if typ != ""` block that applies templates), add:
+
+```go
+var tagWarning string
+if tagStr, ok := argString(args, "tags"); ok && tagStr != "" {
+    tags := strings.Split(tagStr, ",")
+    for i := range tags {
+        tags[i] = strings.TrimSpace(tags[i])
+    }
+    s.UpdateFeature(f.ID, store.FeatureUpdate{Tags: &tags})
+    newTags := s.CheckNewTags(tags)
+    if len(newTags) > 0 {
+        known, _ := s.GetKnownTags()
+        tagWarning = fmt.Sprintf("\nNote: new tag(s) %q added. Existing tags: %s", strings.Join(newTags, ", "), strings.Join(known, ", "))
+    }
+}
+```
+
+Then change the return to include the warning. Replace the final `f, _ = s.GetFeature(f.ID)` and return block with:
+
+```go
+f, _ = s.GetFeature(f.ID)
+data, _ := json.MarshalIndent(f, "", "  ")
+result := string(data)
+if tagWarning != "" {
+    result += tagWarning
+}
+return mcp.NewToolResultText(result), nil
+```
+
+- [ ] **Step 5: Update update_feature handler to handle tags and new-tag warnings**
+
+In `tools_feature.go`, in `updateFeatureHandler`, add tags handling after the `key_files` block:
+
+```go
+if v, ok := argString(args, "tags"); ok {
+    tags := strings.Split(v, ",")
+    for i := range tags {
+        tags[i] = strings.TrimSpace(tags[i])
+    }
+    u.Tags = &tags
+}
+```
+
+After the `s.UpdateFeature(id, u)` call succeeds, add a new-tag warning:
+
+```go
+msg := fmt.Sprintf("Updated feature %q", id)
+if u.Tags != nil {
+    newTags := s.CheckNewTags(*u.Tags)
+    if len(newTags) > 0 {
+        known, _ := s.GetKnownTags()
+        msg += fmt.Sprintf("\nNote: new tag(s) %q added. Existing tags: %s", strings.Join(newTags, ", "), strings.Join(known, ", "))
+    }
+}
+return mcp.NewToolResultText(msg), nil
+```
+
+Remove the old `return mcp.NewToolResultText(fmt.Sprintf("Updated feature %q", id)), nil` line.
+
+- [ ] **Step 6: Update list_features handler to support tag filter**
+
+In `tools_feature.go`, in `listFeaturesHandler`, change to:
+
+```go
+return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+    args := req.GetArguments()
+    status, _ := argString(args, "status")
+    tag, _ := argString(args, "tag")
+
+    var features []store.Feature
+    var err error
+    if tag != "" {
+        features, err = s.ListFeaturesWithTag(status, tag)
+    } else {
+        features, err = s.ListFeatures(status)
+    }
+    if err != nil {
+        return mcp.NewToolResultError(err.Error()), nil
+    }
+
+    if len(features) == 0 {
+        return mcp.NewToolResultText("No features found."), nil
+    }
+
+    var lines []string
+    for _, f := range features {
+        line := fmt.Sprintf("- **%s** [%s] %s", f.ID, f.Status, f.Title)
+        if len(f.Tags) > 0 {
+            line += fmt.Sprintf(" {%s}", strings.Join(f.Tags, ", "))
+        }
+        if f.LeftOff != "" {
+            snippet := f.LeftOff
+            if len(snippet) > 60 {
+                snippet = snippet[:60] + "..."
+            }
+            line += fmt.Sprintf(" — %s", snippet)
+        }
+        lines = append(lines, line)
+    }
+    return mcp.NewToolResultText(strings.Join(lines, "\n")), nil
+}
+```
+
+- [ ] **Step 7: Update list_features tool description to mention archived exclusion**
+
+In `tools.go`, update the `list_features` description and status param:
+
+```go
+srv.AddTool(mcp.NewTool("list_features",
+    mcp.WithDescription("List features. Returns compact summaries: ID, title, status, tags, left_off snippet. Excludes archived by default."),
+    mcp.WithString("status", mcp.Description("Filter by status: planned, in_progress, done, blocked, dev_complete, archived. Omit for all (excluding archived).")),
+    mcp.WithString("tag", mcp.Description("Filter to features with this tag. Combines with status filter.")),
+), listFeaturesHandler(s))
+```
+
+- [ ] **Step 8: Build to check compilation**
+
+Run: `go build ./...`
+Expected: No errors
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `go test ./... -v`
+Expected: All PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/mcp/tools.go internal/mcp/tools_feature.go
+git commit -m "feat: add tags param to add_feature, update_feature, list_features MCP tools"
+```
+
+---
+
+### Task 5: Archival — status extension, completion gate bypass, list exclusion
+
+**Files:**
+- Modify: `internal/store/store.go`
+- Create: `internal/store/archive_test.go`
+
+- [ ] **Step 1: Write failing test for archived status**
+
+Create `internal/store/archive_test.go`:
+
+```go
+package store
+
+import "testing"
+
+func TestArchivedStatus(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	f, _ := s.AddFeature("Old Feature", "")
+	archived := "archived"
+	err := s.UpdateFeature(f.ID, FeatureUpdate{Status: &archived})
+	if err != nil {
+		t.Fatalf("set archived: %v", err)
+	}
+	f, _ = s.GetFeature(f.ID)
+	if f.Status != "archived" {
+		t.Fatalf("expected archived, got %q", f.Status)
+	}
+}
+
+func TestListFeaturesExcludesArchived(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Active", "")
+	s.AddFeature("Old", "")
+	archived := "archived"
+	s.UpdateFeature("old", FeatureUpdate{Status: &archived})
+
+	features, _ := s.ListFeatures("")
+	if len(features) != 1 || features[0].ID != "active" {
+		t.Fatalf("expected only active feature, got %v", features)
+	}
+}
+
+func TestListFeaturesShowArchived(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Old", "")
+	archived := "archived"
+	s.UpdateFeature("old", FeatureUpdate{Status: &archived})
+
+	features, _ := s.ListFeatures("archived")
+	if len(features) != 1 || features[0].ID != "old" {
+		t.Fatalf("expected archived feature, got %v", features)
+	}
+}
+
+func TestCompletionGateBypassForArchived(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	f, _ := s.AddFeature("Archivable", "")
+	s.ApplyTemplate(f.ID, "bugfix") // creates unchecked items
+
+	archived := "archived"
+	err := s.UpdateFeature(f.ID, FeatureUpdate{Status: &archived})
+	if err != nil {
+		t.Fatalf("archiving with unchecked items should work, got: %v", err)
+	}
+	f, _ = s.GetFeature(f.ID)
+	if f.Status != "archived" {
+		t.Fatalf("expected archived, got %q", f.Status)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/store/ -run "TestListFeaturesExcludesArchived" -v`
+Expected: FAIL — archived features still appear in unfiltered list
+
+- [ ] **Step 3: Modify ListFeatures to exclude archived by default**
+
+In `store.go`, `ListFeatures` method, change the query building:
+
+```go
+func (s *Store) ListFeatures(status string) ([]Feature, error) {
+	query := `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features`
+	var args []any
+	if status != "" {
+		query += " WHERE status = ?"
+		args = append(args, status)
+	} else {
+		query += " WHERE status != 'archived'"
+	}
+	query += " ORDER BY updated_at DESC"
+```
+
+Also update `ListFeaturesWithTag` to exclude archived by default:
+
+```go
+func (s *Store) ListFeaturesWithTag(status, tag string) ([]Feature, error) {
+	query := `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE tags LIKE ?`
+	args := []any{"%" + `"` + tag + `"` + "%"}
+	if status != "" {
+		query += " AND status = ?"
+		args = append(args, status)
+	} else {
+		query += " AND status != 'archived'"
+	}
+	query += " ORDER BY updated_at DESC"
+```
+
+- [ ] **Step 4: Run archive tests**
+
+Run: `go test ./internal/store/ -run "TestArchived|TestListFeaturesExcludesArchived|TestListFeaturesShowArchived|TestCompletionGateBypass" -v`
+Expected: `TestCompletionGateBypassForArchived` may still FAIL — completion gate blocks non-done too if it fires
+
+- [ ] **Step 5: Bypass completion gate for archived status**
+
+The completion gate in `UpdateFeature` only fires for `status=done`. Since `archived` is not `done`, it already bypasses. Run the test to confirm:
+
+Run: `go test ./internal/store/ -run TestCompletionGateBypassForArchived -v`
+Expected: PASS (the gate only checks `*u.Status == "done"`)
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `go test ./internal/store/ -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/store/store.go internal/store/archive_test.go
+git commit -m "feat: archived status — exclude from list by default, bypass completion gate"
+```
+
+---
+
+### Task 6: Auto-archive in SessionStart hook
+
+**Files:**
+- Modify: `internal/store/store.go` — new `AutoArchiveStale` method
+- Modify: `cmd/docket/hook.go`
+- Modify: `internal/store/archive_test.go`
+- Modify: `cmd/docket/hook_test.go`
+
+- [ ] **Step 1: Write failing test for AutoArchiveStale**
+
+Append to `internal/store/archive_test.go`:
+
+```go
+import (
+	"testing"
+	"time"
+)
+```
+
+Update the package imports (replace the existing `import "testing"` with the above). Then append:
+
+```go
+func TestAutoArchiveStale(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Old Done", "")
+	done := "done"
+	s.UpdateFeature("old-done", FeatureUpdate{Status: &done})
+
+	// Backdate updated_at to 8 days ago
+	s.db.Exec(`UPDATE features SET updated_at = datetime('now', '-8 days') WHERE id = 'old-done'`)
+
+	s.AddFeature("Recent Done", "")
+	s.UpdateFeature("recent-done", FeatureUpdate{Status: &done})
+
+	archived, err := s.AutoArchiveStale()
+	if err != nil {
+		t.Fatalf("AutoArchiveStale: %v", err)
+	}
+	if len(archived) != 1 || archived[0] != "old-done" {
+		t.Fatalf("expected [old-done], got %v", archived)
+	}
+
+	f, _ := s.GetFeature("old-done")
+	if f.Status != "archived" {
+		t.Fatalf("expected archived, got %q", f.Status)
+	}
+
+	f, _ = s.GetFeature("recent-done")
+	if f.Status != "done" {
+		t.Fatalf("recent should still be done, got %q", f.Status)
+	}
+}
+
+func TestAutoArchiveSkipsRecent(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Fresh Done", "")
+	done := "done"
+	s.UpdateFeature("fresh-done", FeatureUpdate{Status: &done})
+
+	archived, _ := s.AutoArchiveStale()
+	if len(archived) != 0 {
+		t.Fatalf("expected no archival, got %v", archived)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/store/ -run "TestAutoArchive" -v`
+Expected: FAIL — `AutoArchiveStale` undefined
+
+- [ ] **Step 3: Implement AutoArchiveStale**
+
+Add to `store.go`:
+
+```go
+func (s *Store) AutoArchiveStale() ([]string, error) {
+	rows, err := s.db.Query(`SELECT id FROM features WHERE status = 'done' AND updated_at < datetime('now', '-7 days')`)
+	if err != nil {
+		return nil, fmt.Errorf("query stale features: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		rows.Scan(&id)
+		ids = append(ids, id)
+	}
+
+	archived := "archived"
+	for _, id := range ids {
+		s.UpdateFeature(id, FeatureUpdate{Status: &archived})
+	}
+	return ids, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/store/ -run "TestAutoArchive" -v`
+Expected: PASS
+
+- [ ] **Step 5: Add auto-archive call to SessionStart hook**
+
+In `hook.go`, in `handleSessionStart`, right after `defer s.Close()`, add:
+
+```go
+// Auto-archive features done >7 days
+if archived, err := s.AutoArchiveStale(); err == nil && len(archived) > 0 {
+    fmt.Fprintf(os.Stderr, "[docket] Auto-archived %d features: %s\n", len(archived), strings.Join(archived, ", "))
+}
+```
+
+This logs to stderr (visible in debug output) but doesn't inject into the systemMessage — keeping the session start message focused on active work.
+
+- [ ] **Step 6: Write hook test for auto-archive**
+
+Append to `cmd/docket/hook_test.go`:
+
+```go
+func TestSessionStartAutoArchives(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a done feature backdated 8 days
+	s.AddFeature("Old Done Feature", "")
+	done := "done"
+	s.UpdateFeature("old-done-feature", store.FeatureUpdate{Status: &done})
+	s.DB().Exec(`UPDATE features SET updated_at = datetime('now', '-8 days') WHERE id = 'old-done-feature'`)
+
+	// Create an active feature
+	s.AddFeature("Active Feature", "")
+	ip := "in_progress"
+	s.UpdateFeature("active-feature", store.FeatureUpdate{Status: &ip})
+	s.Close()
+
+	h := &hookInput{
+		SessionID:     "test-session",
+		CWD:           dir,
+		HookEventName: "SessionStart",
+	}
+
+	var buf bytes.Buffer
+	handleSessionStart(h, &buf)
+
+	// Verify old feature was archived
+	s2, _ := store.Open(dir)
+	defer s2.Close()
+	f, _ := s2.GetFeature("old-done-feature")
+	if f.Status != "archived" {
+		t.Fatalf("expected archived, got %q", f.Status)
+	}
+}
+```
+
+- [ ] **Step 7: Expose db for testing**
+
+The hook test needs `s.DB()` to backdate. Add this accessor to `store.go`:
+
+```go
+func (s *Store) DB() *sql.DB {
+	return s.db
+}
+```
+
+- [ ] **Step 8: Run hook test**
+
+Run: `go test ./cmd/docket/ -run TestSessionStartAutoArchives -v`
+Expected: PASS
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `go test ./... -v`
+Expected: All PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/store/store.go internal/store/archive_test.go cmd/docket/hook.go cmd/docket/hook_test.go
+git commit -m "feat: auto-archive done features >7 days old in SessionStart hook"
+```
+
+---
+
+### Task 7: Dashboard — tag pills on cards and archived toggle
+
+**Files:**
+- Modify: `dashboard/index.html`
+
+- [ ] **Step 1: Add tag pill CSS**
+
+In the `<style>` section, after the `.issue-badge` light-mode rule (around line 209), add:
+
+```css
+.tag-pill {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  border: 1px solid #4ECDC440;
+  color: var(--teal);
+  margin: 2px 2px 2px 0;
+}
+html.light .tag-pill { border-color: #1A7A7240; color: #1A7A72; }
+```
+
+- [ ] **Step 2: Add archived column CSS**
+
+Add after the `.col-done` styles:
+
+```css
+.col-archived .column-header { color: var(--muted); }
+.col-archived .dot { background: var(--muted); }
+.col-archived .card { opacity: 0.45; }
+.col-archived .card:hover { opacity: 0.8; }
+```
+
+- [ ] **Step 3: Add tag pills to card rendering**
+
+In the JavaScript `render()` function, after the issue-badge block (after `card.appendChild(issueBadge)` closing brace), add:
+
+```javascript
+// Tag pills
+var tags = f.tags || [];
+if (tags.length > 0) {
+  var tagWrap = document.createElement('div');
+  tagWrap.style.marginTop = '6px';
+  for (var ti = 0; ti < tags.length; ti++) {
+    var pill = document.createElement('span');
+    pill.className = 'tag-pill';
+    pill.textContent = tags[ti];
+    tagWrap.appendChild(pill);
+  }
+  card.appendChild(tagWrap);
+}
+```
+
+- [ ] **Step 4: Add tag pills to panel detail view**
+
+In the `showDetail()` function, after the type badge block (after `slugDiv.appendChild(typeBadge)`), add:
+
+```javascript
+if (f.tags && f.tags.length > 0) {
+  for (var ti = 0; ti < f.tags.length; ti++) {
+    var tagPill = document.createElement('span');
+    tagPill.className = 'tag-pill';
+    tagPill.style.marginLeft = '6px';
+    tagPill.textContent = f.tags[ti];
+    slugDiv.appendChild(tagPill);
+  }
+}
+```
+
+- [ ] **Step 5: Add archived toggle and column**
+
+Update the `STATUSES` array and related constants at the top of the script:
+
+```javascript
+var STATUSES = ['planned', 'in_progress', 'blocked', 'dev_complete', 'done'];
+var ALL_STATUSES = ['planned', 'in_progress', 'blocked', 'dev_complete', 'done', 'archived'];
+var STATUS_LABELS = { planned: 'Planned', in_progress: 'In Progress', blocked: 'Blocked', dev_complete: 'Dev Complete', done: 'Done', archived: 'Archived' };
+var STATUS_CSS = { planned: 'col-planned', in_progress: 'col-in-progress', blocked: 'col-blocked', dev_complete: 'col-dev-complete', done: 'col-done', archived: 'col-archived' };
+var showArchived = false;
+```
+
+Add archived badge to header, in `<div class="header-right">`, before the unlinked badge:
+
+```html
+<button class="theme-toggle" id="archiveToggle" onclick="toggleArchived()" title="Show archived features" style="font-size:13px">&#x1F4E6;</button>
+```
+
+Add the toggle function:
+
+```javascript
+function toggleArchived() {
+  showArchived = !showArchived;
+  document.getElementById('archiveToggle').style.borderColor = showArchived ? 'var(--primary)' : '';
+  load();
+}
+```
+
+Update the `load()` function to fetch with or without archived:
+
+```javascript
+async function load() {
+  try {
+    var url = API + '/api/features';
+    if (showArchived) url += '?status=';
+    var res = await fetch(url);
+    features = await res.json();
+  } catch(e) { features = []; }
+  render();
+  loadUnlinked();
+}
+```
+
+Wait — `?status=` with empty value will match `""` in the handler and exclude archived. We need a different approach. The dashboard API uses `GET /api/features` which calls `s.ListFeatures(status)`. With no status, it excludes archived. We need to load archived separately.
+
+Better approach: update `render()` to use the right statuses list:
+
+```javascript
+function render() {
+  var board = document.getElementById('board');
+  board.innerHTML = '';
+  var statuses = showArchived ? ALL_STATUSES : STATUSES;
+  board.style.gridTemplateColumns = 'repeat(' + statuses.length + ', 1fr)';
+  for (var si = 0; si < statuses.length; si++) {
+```
+
+And update `load()` to fetch archived features when the toggle is on:
+
+```javascript
+async function load() {
+  try {
+    var res = await fetch(API + '/api/features');
+    features = await res.json();
+    if (showArchived) {
+      var res2 = await fetch(API + '/api/features?status=archived');
+      var archived = await res2.json();
+      features = features.concat(archived);
+    }
+  } catch(e) { features = []; }
+  render();
+  loadUnlinked();
+}
+```
+
+- [ ] **Step 6: Update board grid for 6 columns when archived visible**
+
+The existing CSS has `grid-template-columns: repeat(5, 1fr)`. The JS override in `render()` handles this dynamically with `board.style.gridTemplateColumns`.
+
+- [ ] **Step 7: Add archived badge style to panel**
+
+Add to the badge styles:
+
+```css
+.badge-archived { background: #8A887810; color: var(--muted); }
+html.light .badge-archived { background: #EAEAEA; color: var(--muted); }
+```
+
+- [ ] **Step 8: Build and visually verify**
+
+Run: `go build -ldflags="-s -w" -o docket.exe ./cmd/docket/`
+Expected: Compiles. Open dashboard to verify tag pills render and archived toggle works.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add dashboard/index.html
+git commit -m "feat: dashboard tag pills and archived feature toggle"
+```
+
+---
+
+### Task 8: CLAUDE.md snippet update
+
+**Files:**
+- Modify: `cmd/docket/update.go`
+
+- [ ] **Step 1: Update docketSection constant**
+
+In `update.go`, update the `docketSection` constant. After the `type` param line in the "Start of work" paragraph, add a new line about tags:
+
+In the "After a commit" section, update the `update_feature` bullet to mention tags:
+
+Replace the `update_feature` bullet line:
+```
+- ` + "`update_feature`" + ` — set left_off, key_files, status. Completion gate blocks ` + "`done`" + ` with unchecked items — pass ` + "`force=true`" + ` + ` + "`force_reason`" + ` to override.
+```
+
+With:
+```
+- ` + "`update_feature`" + ` — set left_off, key_files, status, tags. Completion gate blocks ` + "`done`" + ` with unchecked items — pass ` + "`force=true`" + ` + ` + "`force_reason`" + ` to override.
+```
+
+Add after the "Start of work" paragraph (after the `type` line):
+
+```
+Use ` + "`tags`" + ` param (comma-separated) on ` + "`add_feature`" + `/` + "`update_feature`" + ` to categorize work. New tags warn about existing tags to prevent typos.
+
+Done features are auto-archived after 7 days. Use ` + "`list_features(status=\"archived\")`" + ` to see them. ` + "`update_feature(status=\"planned\")`" + ` to unarchive.
+```
+
+- [ ] **Step 2: Run update command to verify**
+
+Run: `go run ./cmd/docket/ update` (in project root)
+Expected: Updates CLAUDE.md with new snippet
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/docket/update.go
+git commit -m "feat: update CLAUDE.md snippet with tags and archival docs"
+```
+
+---
+
+### Task 9: Update project CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Run the update command to sync the snippet**
+
+Run: `go run ./cmd/docket/ update`
+
+- [ ] **Step 2: Verify CLAUDE.md has the new tags and archival info**
+
+Read `CLAUDE.md` and verify the docket section mentions tags, auto-archive, and archived status.
+
+- [ ] **Step 3: Update the update_feature status list in tools.go description**
+
+In `tools.go`, update the `update_feature` status description:
+
+```go
+mcp.WithString("status", mcp.Description("New status: planned, in_progress, done, blocked, dev_complete, archived")),
+```
+
+- [ ] **Step 4: Build final binary**
+
+Run: `go build -ldflags="-s -w" -o docket.exe ./cmd/docket/`
+Expected: Clean build
+
+- [ ] **Step 5: Run complete test suite**
+
+Run: `go test ./... -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md internal/mcp/tools.go
+git commit -m "docs: update CLAUDE.md snippet and status descriptions for tags/archival"
+```
+
+---
+
+### Task 10: Write feature doc
+
+**Files:**
+- Create: `docs/tags-and-archival.md`
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# Tags and Archival
+
+## What it does
+
+Two additions to feature tracking:
+
+1. **Tags** — free-form string tags on features for categorization. Comma-separated input, stored as JSON array in SQLite. New-tag warnings help catch typos by listing existing tags when you add one that doesn't exist yet.
+
+2. **Archival** — `archived` is a feature status. Done features auto-archive after 7 days (checked on SessionStart). Archived features are hidden from `list_features` and the dashboard by default. No special tool needed — use `update_feature(status="planned")` to unarchive.
+
+## How to use
+
+**Tags:**
+- `add_feature(title="...", tags="auth,frontend")` — set tags on creation
+- `update_feature(id="...", tags="backend,api")` — replace all tags
+- `list_features(tag="auth")` — filter by tag
+
+**Archival:**
+- Features marked `done` for 7+ days auto-archive on next session start
+- `list_features(status="archived")` — see archived features
+- `update_feature(id="...", status="planned")` — unarchive
+- Dashboard has an archive toggle button in the header
+
+## Gotchas
+
+- Tags are exact-match only. No fuzzy matching. The new-tag warning is your typo detector.
+- `tags` param on `update_feature` replaces all tags, not appends. Send the full list.
+- No `list_tags` or `delete_tag` tool. Tags are derived from what features have — unused tags disappear naturally.
+- Auto-archive is hardcoded to 7 days. No config file.
+- Archiving bypasses the completion gate — you can archive features with unchecked items.
+- `get_feature` and `get_context` return any feature regardless of status, including archived.
+
+## Key files
+
+- `internal/store/migrate.go` — schemaV8 (tags column)
+- `internal/store/store.go` — Tags field, GetKnownTags, CheckNewTags, ListFeaturesWithTag, AutoArchiveStale
+- `internal/store/tags_test.go` — tag tests
+- `internal/store/archive_test.go` — archival tests
+- `internal/mcp/tools.go` — tags/tag params on MCP tools
+- `internal/mcp/tools_feature.go` — tag handling in handlers
+- `cmd/docket/hook.go` — auto-archive in SessionStart
+- `dashboard/index.html` — tag pills, archived toggle
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/tags-and-archival.md
+git commit -m "docs: tags and archival feature doc"
+```

--- a/docs/superpowers/plans/2026-03-30-transcript-session-context.md
+++ b/docs/superpowers/plans/2026-03-30-transcript-session-context.md
@@ -1,0 +1,3215 @@
+# Transcript-Based Session Context Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Docket's two-phase Stop hook with checkpoint-based context preservation that uses transcript parsing and background LLM summarization to capture semantic session context automatically.
+
+**Architecture:** Hooks extract transcript deltas and enqueue checkpoint jobs into SQLite. A background worker in the MCP server process drains the queue and calls the Anthropic Messages API for semantic summarization. Handoff files are rendered from accumulated checkpoint observations at SessionEnd or /end-session.
+
+**Tech Stack:** Go, SQLite (modernc.org/sqlite), Anthropic Messages API (net/http), JSONL parsing
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|----------------|
+| `internal/transcript/parse.go` | JSONL transcript reader, delta filter, mechanical fact extractor |
+| `internal/transcript/parse_test.go` | Tests with fixture JSONL data |
+| `internal/transcript/types.go` | `SessionActivity`, `FileAction`, `TestRun`, `ErrorEvent` structs |
+| `internal/checkpoint/worker.go` | Background job queue worker, polls `checkpoint_jobs`, orchestrates summarization |
+| `internal/checkpoint/worker_test.go` | Worker tests with mock summarizer |
+| `internal/checkpoint/summarizer.go` | `SummarizerBackend` interface, `SummarizeInput`/`SummarizeOutput` types |
+| `internal/checkpoint/anthropic.go` | Anthropic Messages API implementation of `SummarizerBackend` |
+| `internal/checkpoint/anthropic_test.go` | Tests with HTTP test server |
+| `internal/checkpoint/config.go` | Config loading from env vars |
+| `internal/checkpoint/noop.go` | No-op summarizer for when no API key is configured |
+| `internal/store/worksession.go` | Work session CRUD (open, close, get active, mark stale) |
+| `internal/store/worksession_test.go` | Work session store tests |
+| `internal/store/checkpoint.go` | Checkpoint job + observation CRUD |
+| `internal/store/checkpoint_test.go` | Checkpoint store tests |
+| `plugin/skills/checkpoint/SKILL.md` | /checkpoint skill definition |
+| `plugin/skills/end-session/SKILL.md` | /end-session skill definition |
+
+### Modified files
+
+| File | Changes |
+|------|---------|
+| `internal/store/migrate.go` | Add schemaV9 with three new tables |
+| `cmd/docket/hook.go` | Rewrite Stop, add PreCompact/SessionEnd handlers, update hookInput struct |
+| `cmd/docket/handoff.go` | Add "Last Session" section from checkpoint observations |
+| `cmd/docket/main.go` | Start checkpoint worker in runServe() |
+| `internal/mcp/tools.go` | Remove `log_session`, add `checkpoint` tool |
+| `internal/mcp/tools_session.go` | Remove `logSessionHandler`, keep `compactSessionsHandler` |
+| `internal/store/store.go` | Remove `MarkSessionLogged`/`WasSessionLogged`/`ClearSessionLogged` |
+| `plugin/hooks/hooks.json` | Add PreCompact/SessionEnd hooks, bump Stop timeout |
+
+---
+
+### Task 1: Schema Migration — New Tables
+
+**Files:**
+- Modify: `internal/store/migrate.go:87-114`
+- Test: `internal/store/feature_test.go` (existing test verifies migration runs)
+
+- [ ] **Step 1: Write the schema migration**
+
+Add `schemaV9` to `internal/store/migrate.go` with the three new tables:
+
+```go
+const schemaV9 = `
+CREATE TABLE IF NOT EXISTS work_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id TEXT NOT NULL REFERENCES features(id),
+    claude_session_id TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'closed')),
+    started_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    ended_at DATETIME,
+    handoff_stale INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS checkpoint_jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    work_session_id INTEGER NOT NULL REFERENCES work_sessions(id),
+    feature_id TEXT NOT NULL,
+    reason TEXT NOT NULL CHECK(reason IN ('stop', 'precompact', 'manual_checkpoint', 'manual_end_session')),
+    trigger_type TEXT NOT NULL DEFAULT '',
+    transcript_start_offset INTEGER NOT NULL DEFAULT 0,
+    transcript_end_offset INTEGER NOT NULL DEFAULT 0,
+    semantic_text TEXT NOT NULL DEFAULT '',
+    mechanical_json TEXT NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'queued' CHECK(status IN ('queued', 'running', 'done', 'failed', 'skipped')),
+    error TEXT NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    started_at DATETIME,
+    finished_at DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS checkpoint_observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    checkpoint_job_id INTEGER NOT NULL REFERENCES checkpoint_jobs(id),
+    work_session_id INTEGER NOT NULL REFERENCES work_sessions(id),
+    feature_id TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK(kind IN ('summary', 'blocker', 'decision_candidate', 'dead_end', 'next_step', 'gotcha')),
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    summary_text TEXT NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+`
+```
+
+- [ ] **Step 2: Wire migration into migrate()**
+
+Add to the `migrate()` function in `internal/store/migrate.go`, after the `db.Exec(schemaV8)` line:
+
+```go
+// v9: add work_sessions, checkpoint_jobs, checkpoint_observations tables
+db.Exec(schemaV9)
+```
+
+- [ ] **Step 3: Run existing tests to verify migration doesn't break anything**
+
+Run: `go test ./internal/store/ -v -run TestAddFeature`
+Expected: PASS (the migration runs silently on every store open)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/store/migrate.go
+git commit -m "feat: add schema v9 — work_sessions, checkpoint_jobs, checkpoint_observations tables"
+```
+
+---
+
+### Task 2: Work Session Store Methods
+
+**Files:**
+- Create: `internal/store/worksession.go`
+- Create: `internal/store/worksession_test.go`
+
+- [ ] **Step 1: Write failing tests for work session lifecycle**
+
+Create `internal/store/worksession_test.go`:
+
+```go
+package store
+
+import (
+    "testing"
+)
+
+func TestOpenWorkSession(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+
+    ws, err := s.OpenWorkSession("auth-system", "session-123")
+    if err != nil {
+        t.Fatalf("OpenWorkSession: %v", err)
+    }
+    if ws.FeatureID != "auth-system" {
+        t.Errorf("FeatureID = %q, want %q", ws.FeatureID, "auth-system")
+    }
+    if ws.ClaudeSessionID != "session-123" {
+        t.Errorf("ClaudeSessionID = %q, want %q", ws.ClaudeSessionID, "session-123")
+    }
+    if ws.Status != "open" {
+        t.Errorf("Status = %q, want %q", ws.Status, "open")
+    }
+}
+
+func TestOpenWorkSessionResumesExisting(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+
+    ws1, _ := s.OpenWorkSession("auth-system", "session-123")
+    ws2, _ := s.OpenWorkSession("auth-system", "session-123")
+
+    if ws1.ID != ws2.ID {
+        t.Errorf("expected same work session ID, got %d and %d", ws1.ID, ws2.ID)
+    }
+}
+
+func TestGetActiveWorkSession(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+
+    _, err := s.GetActiveWorkSession()
+    if err == nil {
+        t.Fatal("expected error when no active work session")
+    }
+
+    s.OpenWorkSession("auth-system", "session-123")
+
+    ws, err := s.GetActiveWorkSession()
+    if err != nil {
+        t.Fatalf("GetActiveWorkSession: %v", err)
+    }
+    if ws.FeatureID != "auth-system" {
+        t.Errorf("FeatureID = %q, want %q", ws.FeatureID, "auth-system")
+    }
+}
+
+func TestCloseWorkSession(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "session-123")
+
+    err := s.CloseWorkSession(ws.ID)
+    if err != nil {
+        t.Fatalf("CloseWorkSession: %v", err)
+    }
+
+    _, err = s.GetActiveWorkSession()
+    if err == nil {
+        t.Fatal("expected no active work session after close")
+    }
+}
+
+func TestMarkHandoffStale(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "session-123")
+
+    s.MarkHandoffStale(ws.ID)
+    ws2, _ := s.GetWorkSession(ws.ID)
+    if !ws2.HandoffStale {
+        t.Error("expected HandoffStale to be true")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/store/ -v -run TestOpenWorkSession`
+Expected: FAIL — `OpenWorkSession` not defined
+
+- [ ] **Step 3: Implement work session store methods**
+
+Create `internal/store/worksession.go`:
+
+```go
+package store
+
+import (
+    "fmt"
+    "time"
+)
+
+type WorkSession struct {
+    ID              int64     `json:"id"`
+    FeatureID       string    `json:"feature_id"`
+    ClaudeSessionID string    `json:"claude_session_id"`
+    Status          string    `json:"status"`
+    StartedAt       time.Time `json:"started_at"`
+    EndedAt         *time.Time `json:"ended_at"`
+    HandoffStale    bool      `json:"handoff_stale"`
+}
+
+// OpenWorkSession opens a new work session or resumes an existing open one
+// for the same feature + claude session.
+func (s *Store) OpenWorkSession(featureID, claudeSessionID string) (*WorkSession, error) {
+    // Try to resume existing open session for same feature+claude session
+    row := s.db.QueryRow(
+        `SELECT id, feature_id, claude_session_id, status, started_at, ended_at, handoff_stale
+         FROM work_sessions WHERE feature_id = ? AND claude_session_id = ? AND status = 'open'`,
+        featureID, claudeSessionID,
+    )
+    ws, err := scanWorkSession(row)
+    if err == nil {
+        return ws, nil
+    }
+
+    // Close any other open sessions (one active session at a time)
+    s.db.Exec(`UPDATE work_sessions SET status = 'closed', ended_at = datetime('now') WHERE status = 'open'`)
+
+    now := time.Now().UTC()
+    res, err := s.db.Exec(
+        `INSERT INTO work_sessions (feature_id, claude_session_id, status, started_at) VALUES (?, ?, 'open', ?)`,
+        featureID, claudeSessionID, now,
+    )
+    if err != nil {
+        return nil, fmt.Errorf("insert work session: %w", err)
+    }
+    id, _ := res.LastInsertId()
+    return s.GetWorkSession(id)
+}
+
+func (s *Store) GetWorkSession(id int64) (*WorkSession, error) {
+    row := s.db.QueryRow(
+        `SELECT id, feature_id, claude_session_id, status, started_at, ended_at, handoff_stale
+         FROM work_sessions WHERE id = ?`, id,
+    )
+    return scanWorkSession(row)
+}
+
+// GetActiveWorkSession returns the single open work session, or error if none.
+func (s *Store) GetActiveWorkSession() (*WorkSession, error) {
+    row := s.db.QueryRow(
+        `SELECT id, feature_id, claude_session_id, status, started_at, ended_at, handoff_stale
+         FROM work_sessions WHERE status = 'open' ORDER BY id DESC LIMIT 1`,
+    )
+    return scanWorkSession(row)
+}
+
+func (s *Store) CloseWorkSession(id int64) error {
+    _, err := s.db.Exec(
+        `UPDATE work_sessions SET status = 'closed', ended_at = datetime('now') WHERE id = ?`, id,
+    )
+    return err
+}
+
+func (s *Store) MarkHandoffStale(id int64) {
+    s.db.Exec(`UPDATE work_sessions SET handoff_stale = 1 WHERE id = ?`, id)
+}
+
+type scannable interface {
+    Scan(dest ...any) error
+}
+
+func scanWorkSession(row scannable) (*WorkSession, error) {
+    var ws WorkSession
+    var stale int
+    err := row.Scan(&ws.ID, &ws.FeatureID, &ws.ClaudeSessionID, &ws.Status, &ws.StartedAt, &ws.EndedAt, &stale)
+    if err != nil {
+        return nil, err
+    }
+    ws.HandoffStale = stale != 0
+    return &ws, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/store/ -v -run "TestOpenWorkSession|TestGetActiveWorkSession|TestCloseWorkSession|TestMarkHandoffStale"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/worksession.go internal/store/worksession_test.go
+git commit -m "feat: add work session store methods — open, close, get active, mark stale"
+```
+
+---
+
+### Task 3: Checkpoint Store Methods
+
+**Files:**
+- Create: `internal/store/checkpoint.go`
+- Create: `internal/store/checkpoint_test.go`
+
+- [ ] **Step 1: Write failing tests for checkpoint job and observation CRUD**
+
+Create `internal/store/checkpoint_test.go`:
+
+```go
+package store
+
+import (
+    "encoding/json"
+    "testing"
+)
+
+func TestEnqueueCheckpointJob(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    job, err := s.EnqueueCheckpointJob(CheckpointJobInput{
+        WorkSessionID:        ws.ID,
+        FeatureID:            "auth-system",
+        Reason:               "stop",
+        TriggerType:          "auto",
+        TranscriptStartOffset: 0,
+        TranscriptEndOffset:  1024,
+        SemanticText:         "discussed auth token design",
+        MechanicalFacts:      MechanicalFacts{FilesEdited: []FileEdit{{Path: "auth.go", Count: 2}}},
+    })
+    if err != nil {
+        t.Fatalf("EnqueueCheckpointJob: %v", err)
+    }
+    if job.Status != "queued" {
+        t.Errorf("Status = %q, want %q", job.Status, "queued")
+    }
+    if job.FeatureID != "auth-system" {
+        t.Errorf("FeatureID = %q, want %q", job.FeatureID, "auth-system")
+    }
+}
+
+func TestDequeueCheckpointJob(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    s.EnqueueCheckpointJob(CheckpointJobInput{
+        WorkSessionID:        ws.ID,
+        FeatureID:            "auth-system",
+        Reason:               "stop",
+        TranscriptStartOffset: 0,
+        TranscriptEndOffset:  512,
+        SemanticText:         "some text",
+        MechanicalFacts:      MechanicalFacts{},
+    })
+
+    job, err := s.DequeueCheckpointJob()
+    if err != nil {
+        t.Fatalf("DequeueCheckpointJob: %v", err)
+    }
+    if job == nil {
+        t.Fatal("expected a job, got nil")
+    }
+    if job.Status != "running" {
+        t.Errorf("Status = %q, want %q", job.Status, "running")
+    }
+
+    // Second dequeue should return nil (no more queued jobs)
+    job2, _ := s.DequeueCheckpointJob()
+    if job2 != nil {
+        t.Error("expected nil on second dequeue")
+    }
+}
+
+func TestCompleteCheckpointJob(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    enqueued, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+        WorkSessionID:        ws.ID,
+        FeatureID:            "auth-system",
+        Reason:               "stop",
+        TranscriptStartOffset: 0,
+        TranscriptEndOffset:  512,
+        SemanticText:         "text",
+        MechanicalFacts:      MechanicalFacts{},
+    })
+
+    s.DequeueCheckpointJob()
+    err := s.CompleteCheckpointJob(enqueued.ID, nil)
+    if err != nil {
+        t.Fatalf("CompleteCheckpointJob: %v", err)
+    }
+
+    job, _ := s.GetCheckpointJob(enqueued.ID)
+    if job.Status != "done" {
+        t.Errorf("Status = %q, want %q", job.Status, "done")
+    }
+}
+
+func TestFailCheckpointJob(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    enqueued, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+        WorkSessionID:        ws.ID,
+        FeatureID:            "auth-system",
+        Reason:               "stop",
+        TranscriptStartOffset: 0,
+        TranscriptEndOffset:  512,
+        SemanticText:         "text",
+        MechanicalFacts:      MechanicalFacts{},
+    })
+
+    s.DequeueCheckpointJob()
+    err := s.FailCheckpointJob(enqueued.ID, "api timeout")
+    if err != nil {
+        t.Fatalf("FailCheckpointJob: %v", err)
+    }
+
+    job, _ := s.GetCheckpointJob(enqueued.ID)
+    if job.Status != "failed" {
+        t.Errorf("Status = %q, want %q", job.Status, "failed")
+    }
+    if job.Error != "api timeout" {
+        t.Errorf("Error = %q, want %q", job.Error, "api timeout")
+    }
+}
+
+func TestAddCheckpointObservation(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    job, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+        WorkSessionID:        ws.ID,
+        FeatureID:            "auth-system",
+        Reason:               "stop",
+        TranscriptStartOffset: 0,
+        TranscriptEndOffset:  512,
+        SemanticText:         "text",
+        MechanicalFacts:      MechanicalFacts{},
+    })
+
+    obs, err := s.AddCheckpointObservation(CheckpointObservationInput{
+        CheckpointJobID: job.ID,
+        WorkSessionID:   ws.ID,
+        FeatureID:       "auth-system",
+        Kind:            "summary",
+        PayloadJSON:     `{"goals": ["implement refresh tokens"]}`,
+        SummaryText:     "Discussed token refresh design. Decided to use rotating refresh tokens.",
+    })
+    if err != nil {
+        t.Fatalf("AddCheckpointObservation: %v", err)
+    }
+    if obs.Kind != "summary" {
+        t.Errorf("Kind = %q, want %q", obs.Kind, "summary")
+    }
+}
+
+func TestGetObservationsForWorkSession(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    job, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+        WorkSessionID: ws.ID, FeatureID: "auth-system", Reason: "stop",
+        TranscriptStartOffset: 0, TranscriptEndOffset: 512,
+        SemanticText: "text", MechanicalFacts: MechanicalFacts{},
+    })
+
+    s.AddCheckpointObservation(CheckpointObservationInput{
+        CheckpointJobID: job.ID, WorkSessionID: ws.ID, FeatureID: "auth-system",
+        Kind: "summary", SummaryText: "First checkpoint",
+    })
+    s.AddCheckpointObservation(CheckpointObservationInput{
+        CheckpointJobID: job.ID, WorkSessionID: ws.ID, FeatureID: "auth-system",
+        Kind: "blocker", SummaryText: "Need API key for external service",
+    })
+
+    obs, err := s.GetObservationsForWorkSession(ws.ID)
+    if err != nil {
+        t.Fatalf("GetObservationsForWorkSession: %v", err)
+    }
+    if len(obs) != 2 {
+        t.Fatalf("got %d observations, want 2", len(obs))
+    }
+}
+
+func TestCheckpointIdempotency(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    input := CheckpointJobInput{
+        WorkSessionID:        ws.ID,
+        FeatureID:            "auth-system",
+        Reason:               "stop",
+        TranscriptStartOffset: 0,
+        TranscriptEndOffset:  512,
+        SemanticText:         "text",
+        MechanicalFacts:      MechanicalFacts{},
+    }
+
+    job1, _ := s.EnqueueCheckpointJob(input)
+    job2, _ := s.EnqueueCheckpointJob(input)
+
+    if job1.ID != job2.ID {
+        t.Errorf("expected idempotent enqueue, got IDs %d and %d", job1.ID, job2.ID)
+    }
+}
+
+func TestGetMechanicalFactsForWorkSession(t *testing.T) {
+    s := openTestStore(t)
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    facts1 := MechanicalFacts{
+        FilesEdited: []FileEdit{{Path: "auth.go", Count: 2}},
+        Commits:     []CommitFact{{Hash: "abc123", Message: "add auth"}},
+    }
+    facts2 := MechanicalFacts{
+        FilesEdited: []FileEdit{{Path: "middleware.go", Count: 1}},
+        TestRuns:    []TestRunFact{{Command: "go test ./...", Passed: true}},
+    }
+
+    s.EnqueueCheckpointJob(CheckpointJobInput{
+        WorkSessionID: ws.ID, FeatureID: "auth-system", Reason: "stop",
+        TranscriptStartOffset: 0, TranscriptEndOffset: 512,
+        SemanticText: "text", MechanicalFacts: facts1,
+    })
+    s.EnqueueCheckpointJob(CheckpointJobInput{
+        WorkSessionID: ws.ID, FeatureID: "auth-system", Reason: "stop",
+        TranscriptStartOffset: 512, TranscriptEndOffset: 1024,
+        SemanticText: "more text", MechanicalFacts: facts2,
+    })
+
+    merged, err := s.GetMechanicalFactsForWorkSession(ws.ID)
+    if err != nil {
+        t.Fatalf("GetMechanicalFactsForWorkSession: %v", err)
+    }
+    if len(merged.FilesEdited) != 2 {
+        t.Errorf("FilesEdited = %d, want 2", len(merged.FilesEdited))
+    }
+    if len(merged.Commits) != 1 {
+        t.Errorf("Commits = %d, want 1", len(merged.Commits))
+    }
+    if len(merged.TestRuns) != 1 {
+        t.Errorf("TestRuns = %d, want 1", len(merged.TestRuns))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/store/ -v -run "TestEnqueueCheckpoint|TestDequeueCheckpoint|TestCompleteCheckpoint|TestFailCheckpoint|TestAddCheckpointObservation|TestGetObservations|TestCheckpointIdempotency|TestGetMechanicalFacts"`
+Expected: FAIL — types and methods not defined
+
+- [ ] **Step 3: Implement checkpoint store types and methods**
+
+Create `internal/store/checkpoint.go`:
+
+```go
+package store
+
+import (
+    "encoding/json"
+    "fmt"
+    "time"
+)
+
+type FileEdit struct {
+    Path  string `json:"path"`
+    Count int    `json:"count"`
+}
+
+type TestRunFact struct {
+    Command string `json:"command"`
+    Passed  bool   `json:"passed"`
+}
+
+type CommitFact struct {
+    Hash    string `json:"hash"`
+    Message string `json:"message"`
+}
+
+type ErrorFact struct {
+    Tool    string `json:"tool"`
+    Message string `json:"message"`
+}
+
+type MechanicalFacts struct {
+    FilesEdited []FileEdit    `json:"files_edited,omitempty"`
+    TestRuns    []TestRunFact `json:"test_runs,omitempty"`
+    Commits     []CommitFact  `json:"commits,omitempty"`
+    Errors      []ErrorFact   `json:"errors,omitempty"`
+}
+
+type CheckpointJob struct {
+    ID                    int64      `json:"id"`
+    WorkSessionID         int64      `json:"work_session_id"`
+    FeatureID             string     `json:"feature_id"`
+    Reason                string     `json:"reason"`
+    TriggerType           string     `json:"trigger_type"`
+    TranscriptStartOffset int64      `json:"transcript_start_offset"`
+    TranscriptEndOffset   int64      `json:"transcript_end_offset"`
+    SemanticText          string     `json:"semantic_text"`
+    MechanicalJSON        string     `json:"mechanical_json"`
+    Status                string     `json:"status"`
+    Error                 string     `json:"error"`
+    CreatedAt             time.Time  `json:"created_at"`
+    StartedAt             *time.Time `json:"started_at"`
+    FinishedAt            *time.Time `json:"finished_at"`
+}
+
+type CheckpointJobInput struct {
+    WorkSessionID         int64
+    FeatureID             string
+    Reason                string
+    TriggerType           string
+    TranscriptStartOffset int64
+    TranscriptEndOffset   int64
+    SemanticText          string
+    MechanicalFacts       MechanicalFacts
+}
+
+type CheckpointObservation struct {
+    ID              int64     `json:"id"`
+    CheckpointJobID int64     `json:"checkpoint_job_id"`
+    WorkSessionID   int64     `json:"work_session_id"`
+    FeatureID       string    `json:"feature_id"`
+    Kind            string    `json:"kind"`
+    PayloadJSON     string    `json:"payload_json"`
+    SummaryText     string    `json:"summary_text"`
+    CreatedAt       time.Time `json:"created_at"`
+}
+
+type CheckpointObservationInput struct {
+    CheckpointJobID int64
+    WorkSessionID   int64
+    FeatureID       string
+    Kind            string
+    PayloadJSON     string
+    SummaryText     string
+}
+
+// EnqueueCheckpointJob inserts a checkpoint job. Idempotent — if a job with
+// the same work_session_id + transcript offsets + feature_id already exists,
+// returns the existing job.
+func (s *Store) EnqueueCheckpointJob(input CheckpointJobInput) (*CheckpointJob, error) {
+    // Idempotency check
+    row := s.db.QueryRow(
+        `SELECT id FROM checkpoint_jobs
+         WHERE work_session_id = ? AND feature_id = ?
+           AND transcript_start_offset = ? AND transcript_end_offset = ?`,
+        input.WorkSessionID, input.FeatureID,
+        input.TranscriptStartOffset, input.TranscriptEndOffset,
+    )
+    var existingID int64
+    if err := row.Scan(&existingID); err == nil {
+        return s.GetCheckpointJob(existingID)
+    }
+
+    mechJSON, _ := json.Marshal(input.MechanicalFacts)
+    res, err := s.db.Exec(
+        `INSERT INTO checkpoint_jobs
+         (work_session_id, feature_id, reason, trigger_type,
+          transcript_start_offset, transcript_end_offset,
+          semantic_text, mechanical_json, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'queued')`,
+        input.WorkSessionID, input.FeatureID, input.Reason, input.TriggerType,
+        input.TranscriptStartOffset, input.TranscriptEndOffset,
+        input.SemanticText, string(mechJSON),
+    )
+    if err != nil {
+        return nil, fmt.Errorf("enqueue checkpoint job: %w", err)
+    }
+    id, _ := res.LastInsertId()
+    return s.GetCheckpointJob(id)
+}
+
+// DequeueCheckpointJob atomically picks the oldest queued job and marks it running.
+func (s *Store) DequeueCheckpointJob() (*CheckpointJob, error) {
+    tx, err := s.db.Begin()
+    if err != nil {
+        return nil, err
+    }
+    defer tx.Rollback()
+
+    row := tx.QueryRow(
+        `SELECT id FROM checkpoint_jobs WHERE status = 'queued' ORDER BY id ASC LIMIT 1`,
+    )
+    var id int64
+    if err := row.Scan(&id); err != nil {
+        return nil, nil // no queued jobs
+    }
+
+    _, err = tx.Exec(
+        `UPDATE checkpoint_jobs SET status = 'running', started_at = datetime('now') WHERE id = ?`, id,
+    )
+    if err != nil {
+        return nil, err
+    }
+
+    if err := tx.Commit(); err != nil {
+        return nil, err
+    }
+    return s.GetCheckpointJob(id)
+}
+
+func (s *Store) CompleteCheckpointJob(id int64, errMsg *string) error {
+    if errMsg != nil {
+        return s.FailCheckpointJob(id, *errMsg)
+    }
+    _, err := s.db.Exec(
+        `UPDATE checkpoint_jobs SET status = 'done', finished_at = datetime('now') WHERE id = ?`, id,
+    )
+    return err
+}
+
+func (s *Store) FailCheckpointJob(id int64, errMsg string) error {
+    _, err := s.db.Exec(
+        `UPDATE checkpoint_jobs SET status = 'failed', error = ?, finished_at = datetime('now') WHERE id = ?`,
+        errMsg, id,
+    )
+    return err
+}
+
+func (s *Store) GetCheckpointJob(id int64) (*CheckpointJob, error) {
+    row := s.db.QueryRow(
+        `SELECT id, work_session_id, feature_id, reason, trigger_type,
+                transcript_start_offset, transcript_end_offset,
+                semantic_text, mechanical_json, status, error,
+                created_at, started_at, finished_at
+         FROM checkpoint_jobs WHERE id = ?`, id,
+    )
+    var job CheckpointJob
+    err := row.Scan(
+        &job.ID, &job.WorkSessionID, &job.FeatureID, &job.Reason, &job.TriggerType,
+        &job.TranscriptStartOffset, &job.TranscriptEndOffset,
+        &job.SemanticText, &job.MechanicalJSON, &job.Status, &job.Error,
+        &job.CreatedAt, &job.StartedAt, &job.FinishedAt,
+    )
+    if err != nil {
+        return nil, fmt.Errorf("get checkpoint job %d: %w", id, err)
+    }
+    return &job, nil
+}
+
+func (s *Store) AddCheckpointObservation(input CheckpointObservationInput) (*CheckpointObservation, error) {
+    if input.PayloadJSON == "" {
+        input.PayloadJSON = "{}"
+    }
+    res, err := s.db.Exec(
+        `INSERT INTO checkpoint_observations
+         (checkpoint_job_id, work_session_id, feature_id, kind, payload_json, summary_text)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        input.CheckpointJobID, input.WorkSessionID, input.FeatureID,
+        input.Kind, input.PayloadJSON, input.SummaryText,
+    )
+    if err != nil {
+        return nil, fmt.Errorf("add checkpoint observation: %w", err)
+    }
+    id, _ := res.LastInsertId()
+    row := s.db.QueryRow(
+        `SELECT id, checkpoint_job_id, work_session_id, feature_id, kind, payload_json, summary_text, created_at
+         FROM checkpoint_observations WHERE id = ?`, id,
+    )
+    var obs CheckpointObservation
+    err = row.Scan(&obs.ID, &obs.CheckpointJobID, &obs.WorkSessionID, &obs.FeatureID,
+        &obs.Kind, &obs.PayloadJSON, &obs.SummaryText, &obs.CreatedAt)
+    if err != nil {
+        return nil, err
+    }
+    return &obs, nil
+}
+
+func (s *Store) GetObservationsForWorkSession(workSessionID int64) ([]CheckpointObservation, error) {
+    rows, err := s.db.Query(
+        `SELECT id, checkpoint_job_id, work_session_id, feature_id, kind, payload_json, summary_text, created_at
+         FROM checkpoint_observations WHERE work_session_id = ? ORDER BY id ASC`, workSessionID,
+    )
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+    var obs []CheckpointObservation
+    for rows.Next() {
+        var o CheckpointObservation
+        if err := rows.Scan(&o.ID, &o.CheckpointJobID, &o.WorkSessionID, &o.FeatureID,
+            &o.Kind, &o.PayloadJSON, &o.SummaryText, &o.CreatedAt); err != nil {
+            return nil, err
+        }
+        obs = append(obs, o)
+    }
+    return obs, nil
+}
+
+// GetMechanicalFactsForWorkSession merges mechanical facts from all checkpoint
+// jobs in a work session into a single MechanicalFacts.
+func (s *Store) GetMechanicalFactsForWorkSession(workSessionID int64) (*MechanicalFacts, error) {
+    rows, err := s.db.Query(
+        `SELECT mechanical_json FROM checkpoint_jobs WHERE work_session_id = ? ORDER BY id ASC`,
+        workSessionID,
+    )
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+
+    merged := &MechanicalFacts{}
+    for rows.Next() {
+        var raw string
+        if err := rows.Scan(&raw); err != nil {
+            continue
+        }
+        var facts MechanicalFacts
+        if err := json.Unmarshal([]byte(raw), &facts); err != nil {
+            continue
+        }
+        merged.FilesEdited = append(merged.FilesEdited, facts.FilesEdited...)
+        merged.TestRuns = append(merged.TestRuns, facts.TestRuns...)
+        merged.Commits = append(merged.Commits, facts.Commits...)
+        merged.Errors = append(merged.Errors, facts.Errors...)
+    }
+    return merged, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/store/ -v -run "TestEnqueueCheckpoint|TestDequeueCheckpoint|TestCompleteCheckpoint|TestFailCheckpoint|TestAddCheckpointObservation|TestGetObservations|TestCheckpointIdempotency|TestGetMechanicalFacts"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/checkpoint.go internal/store/checkpoint_test.go
+git commit -m "feat: add checkpoint job queue and observation store methods"
+```
+
+---
+
+### Task 4: Transcript Parser
+
+**Files:**
+- Create: `internal/transcript/types.go`
+- Create: `internal/transcript/parse.go`
+- Create: `internal/transcript/parse_test.go`
+
+- [ ] **Step 1: Define transcript types**
+
+Create `internal/transcript/types.go`:
+
+```go
+package transcript
+
+import "github.com/sniffle6/claude-docket/internal/store"
+
+// Delta is the result of parsing a transcript range. It contains
+// filtered semantic text (user/assistant only) and mechanical facts.
+type Delta struct {
+    SemanticText    string              // filtered user+assistant text
+    MechanicalFacts store.MechanicalFacts
+    EndOffset       int64               // byte offset after last processed line
+    HasContent      bool                // true if any non-trivial content found
+}
+
+// trivialUserMessages are acknowledgment-only messages that don't count
+// as meaningful user input.
+var trivialUserMessages = map[string]bool{
+    "ok":       true,
+    "okay":     true,
+    "thanks":   true,
+    "thank you": true,
+    "continue": true,
+    "go on":    true,
+    "run it":   true,
+    "yep":      true,
+    "yes":      true,
+    "yeah":     true,
+    "sure":     true,
+    "go":       true,
+    "do it":    true,
+    "looks good": true,
+    "lgtm":     true,
+    "sounds good": true,
+}
+```
+
+- [ ] **Step 2: Write failing tests for transcript parsing**
+
+Create `internal/transcript/parse_test.go`:
+
+```go
+package transcript
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+)
+
+func writeFixture(t *testing.T, lines ...string) string {
+    t.Helper()
+    dir := t.TempDir()
+    path := filepath.Join(dir, "transcript.jsonl")
+    var content string
+    for _, line := range lines {
+        content += line + "\n"
+    }
+    os.WriteFile(path, []byte(content), 0644)
+    return path
+}
+
+func TestParseAssistantText(t *testing.T) {
+    path := writeFixture(t,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll fix the auth bug by updating the token validation."}]}}`,
+    )
+    delta, err := Parse(path, 0)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    if delta.SemanticText == "" {
+        t.Error("expected semantic text from assistant message")
+    }
+    if !delta.HasContent {
+        t.Error("expected HasContent=true")
+    }
+}
+
+func TestParseFiltersToolResults(t *testing.T) {
+    path := writeFixture(t,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Let me read the file."},{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"/tmp/foo.go"}}]}}`,
+        `{"type":"tool_result","tool_use_id":"t1","content":"package main\nfunc main() {}"}`,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The file looks correct."}]}}`,
+    )
+    delta, err := Parse(path, 0)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    // Should contain assistant text but not the tool result content
+    if len(delta.SemanticText) > 200 {
+        t.Errorf("semantic text too long (%d chars), likely includes tool result", len(delta.SemanticText))
+    }
+}
+
+func TestParseExtractsFileEdits(t *testing.T) {
+    path := writeFixture(t,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"/tmp/store.go","old_string":"foo","new_string":"bar"}}]}}`,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Edit","input":{"file_path":"/tmp/store.go","old_string":"baz","new_string":"qux"}}]}}`,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t3","name":"Write","input":{"file_path":"/tmp/new.go","content":"package new"}}]}}`,
+    )
+    delta, err := Parse(path, 0)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    if len(delta.MechanicalFacts.FilesEdited) != 2 {
+        t.Errorf("FilesEdited = %d, want 2 (store.go counted once, new.go once)", len(delta.MechanicalFacts.FilesEdited))
+    }
+}
+
+func TestParseExtractsTestRuns(t *testing.T) {
+    path := writeFixture(t,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"go test ./..."}}]}}`,
+        `{"type":"tool_result","tool_use_id":"t1","content":"ok  \tpkg\t0.5s","isError":false}`,
+    )
+    delta, err := Parse(path, 0)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    if len(delta.MechanicalFacts.TestRuns) != 1 {
+        t.Fatalf("TestRuns = %d, want 1", len(delta.MechanicalFacts.TestRuns))
+    }
+    if !delta.MechanicalFacts.TestRuns[0].Passed {
+        t.Error("expected test run to show as passed")
+    }
+}
+
+func TestParseExtractsErrors(t *testing.T) {
+    path := writeFixture(t,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls /nonexistent"}}]}}`,
+        `{"type":"tool_result","tool_use_id":"t1","content":"ls: cannot access '/nonexistent'","isError":true}`,
+    )
+    delta, err := Parse(path, 0)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    if len(delta.MechanicalFacts.Errors) != 1 {
+        t.Fatalf("Errors = %d, want 1", len(delta.MechanicalFacts.Errors))
+    }
+}
+
+func TestParseFromOffset(t *testing.T) {
+    line1 := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"First message."}]}}`
+    line2 := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Second message."}]}}`
+    path := writeFixture(t, line1, line2)
+
+    // Parse from offset after first line
+    offset := int64(len(line1) + 1) // +1 for newline
+    delta, err := Parse(path, offset)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    if delta.SemanticText != "Second message.\n" {
+        t.Errorf("SemanticText = %q, want only second message", delta.SemanticText)
+    }
+}
+
+func TestParseTrivialUserMessages(t *testing.T) {
+    path := writeFixture(t,
+        `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"ok"}]}}`,
+        `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"thanks"}]}}`,
+    )
+    delta, err := Parse(path, 0)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    if delta.HasContent {
+        t.Error("expected HasContent=false for trivial-only messages")
+    }
+}
+
+func TestParseSkipsMalformedLines(t *testing.T) {
+    path := writeFixture(t,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Good line."}]}}`,
+        `this is not json`,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Another good line."}]}}`,
+    )
+    delta, err := Parse(path, 0)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    if delta.SemanticText == "" {
+        t.Error("expected semantic text from non-malformed lines")
+    }
+}
+
+func TestParseMissingFile(t *testing.T) {
+    delta, err := Parse("/nonexistent/transcript.jsonl", 0)
+    if err != nil {
+        t.Fatalf("expected no error for missing file, got: %v", err)
+    }
+    if delta.HasContent {
+        t.Error("expected empty delta for missing file")
+    }
+}
+
+func TestParseExtractsCommits(t *testing.T) {
+    path := writeFixture(t,
+        `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"git commit -m \"fix auth bug\""}}]}}`,
+        `{"type":"tool_result","tool_use_id":"t1","content":"[main abc1234] fix auth bug\n 1 file changed","isError":false}`,
+    )
+    delta, err := Parse(path, 0)
+    if err != nil {
+        t.Fatalf("Parse: %v", err)
+    }
+    if len(delta.MechanicalFacts.Commits) != 1 {
+        t.Fatalf("Commits = %d, want 1", len(delta.MechanicalFacts.Commits))
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./internal/transcript/ -v`
+Expected: FAIL — `Parse` not defined
+
+- [ ] **Step 4: Implement transcript parser**
+
+Create `internal/transcript/parse.go`:
+
+```go
+package transcript
+
+import (
+    "bufio"
+    "encoding/json"
+    "fmt"
+    "os"
+    "regexp"
+    "strings"
+
+    "github.com/sniffle6/claude-docket/internal/store"
+)
+
+// transcriptRecord represents one line in the JSONL transcript.
+type transcriptRecord struct {
+    Type    string          `json:"type"`
+    Message *messagePayload `json:"message"`
+    // tool_result fields
+    ToolUseID string          `json:"tool_use_id"`
+    Content   json.RawMessage `json:"content"`
+    IsError   bool            `json:"isError"`
+}
+
+type messagePayload struct {
+    Role    string         `json:"role"`
+    Content []contentBlock `json:"content"`
+}
+
+type contentBlock struct {
+    Type  string          `json:"type"`
+    Text  string          `json:"text"`
+    Name  string          `json:"name"`
+    ID    string          `json:"id"`
+    Input json.RawMessage `json:"input"`
+}
+
+type toolInput struct {
+    FilePath string `json:"file_path"`
+    Command  string `json:"command"`
+}
+
+var (
+    testCmdPattern  = regexp.MustCompile(`(?i)(go test|npm test|pytest|jest|cargo test|make test)`)
+    commitPattern   = regexp.MustCompile(`\[[\w/.-]+ ([a-f0-9]{7,40})\] (.+)`)
+)
+
+// Parse reads a JSONL transcript from startOffset and returns a Delta
+// containing filtered semantic text and mechanical facts.
+// Returns an empty Delta (not an error) if the file doesn't exist or is empty.
+func Parse(path string, startOffset int64) (*Delta, error) {
+    f, err := os.Open(path)
+    if err != nil {
+        // Missing file = empty delta, not an error
+        return &Delta{EndOffset: startOffset}, nil
+    }
+    defer f.Close()
+
+    if startOffset > 0 {
+        if _, err := f.Seek(startOffset, 0); err != nil {
+            return &Delta{EndOffset: startOffset}, nil
+        }
+    }
+
+    delta := &Delta{EndOffset: startOffset}
+    var semanticBuf strings.Builder
+
+    // Track pending tool uses for matching with results
+    pendingTools := make(map[string]contentBlock) // tool_use_id -> block
+    fileEditCounts := make(map[string]int)
+
+    scanner := bufio.NewScanner(f)
+    scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // up to 10MB lines
+
+    for scanner.Scan() {
+        line := scanner.Bytes()
+        delta.EndOffset += int64(len(line)) + 1 // +1 for newline
+
+        var rec transcriptRecord
+        if err := json.Unmarshal(line, &rec); err != nil {
+            fmt.Fprintf(os.Stderr, "docket transcript: skip malformed line: %v\n", err)
+            continue
+        }
+
+        switch rec.Type {
+        case "assistant":
+            if rec.Message == nil {
+                continue
+            }
+            for _, block := range rec.Message.Content {
+                switch block.Type {
+                case "text":
+                    if block.Text != "" {
+                        semanticBuf.WriteString(block.Text)
+                        semanticBuf.WriteByte('\n')
+                    }
+                case "tool_use":
+                    pendingTools[block.ID] = block
+                    processToolUse(block, fileEditCounts)
+                }
+            }
+
+        case "user":
+            if rec.Message == nil {
+                continue
+            }
+            for _, block := range rec.Message.Content {
+                if block.Type == "text" && block.Text != "" {
+                    normalized := strings.ToLower(strings.TrimSpace(block.Text))
+                    if !trivialUserMessages[normalized] {
+                        delta.HasContent = true
+                    }
+                    // Include user text in semantic output regardless
+                    semanticBuf.WriteString(block.Text)
+                    semanticBuf.WriteByte('\n')
+                }
+            }
+
+        case "tool_result":
+            if pending, ok := pendingTools[rec.ToolUseID]; ok {
+                processToolResult(pending, rec, delta)
+                delete(pendingTools, rec.ToolUseID)
+            }
+        }
+    }
+
+    // Convert file edit counts to FileEdit slice
+    for path, count := range fileEditCounts {
+        delta.MechanicalFacts.FilesEdited = append(delta.MechanicalFacts.FilesEdited, store.FileEdit{
+            Path: path, Count: count,
+        })
+    }
+
+    delta.SemanticText = semanticBuf.String()
+    if len(delta.SemanticText) >= 300 {
+        delta.HasContent = true
+    }
+
+    return delta, nil
+}
+
+func processToolUse(block contentBlock, fileEditCounts map[string]int) {
+    var ti toolInput
+    json.Unmarshal(block.Input, &ti)
+
+    switch block.Name {
+    case "Edit", "Write":
+        if ti.FilePath != "" {
+            fileEditCounts[ti.FilePath]++
+        }
+    }
+}
+
+func processToolResult(pending contentBlock, rec transcriptRecord, delta *Delta) {
+    var resultText string
+    // Content can be a string or an array
+    if err := json.Unmarshal(rec.Content, &resultText); err != nil {
+        // Try as raw string (already a string)
+        resultText = string(rec.Content)
+    }
+
+    var ti toolInput
+    json.Unmarshal(pending.Input, &ti)
+
+    // Check for errors
+    if rec.IsError {
+        delta.MechanicalFacts.Errors = append(delta.MechanicalFacts.Errors, store.ErrorFact{
+            Tool:    pending.Name,
+            Message: truncate(resultText, 200),
+        })
+    }
+
+    // Bash-specific analysis
+    if pending.Name == "Bash" {
+        // Test detection
+        if testCmdPattern.MatchString(ti.Command) {
+            passed := !rec.IsError
+            delta.MechanicalFacts.TestRuns = append(delta.MechanicalFacts.TestRuns, store.TestRunFact{
+                Command: ti.Command,
+                Passed:  passed,
+            })
+        }
+
+        // Commit detection
+        if strings.Contains(ti.Command, "git commit") {
+            if matches := commitPattern.FindStringSubmatch(resultText); len(matches) >= 3 {
+                delta.MechanicalFacts.Commits = append(delta.MechanicalFacts.Commits, store.CommitFact{
+                    Hash:    matches[1],
+                    Message: matches[2],
+                })
+            }
+        }
+    }
+}
+
+func truncate(s string, max int) string {
+    if len(s) <= max {
+        return s
+    }
+    return s[:max] + "..."
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/transcript/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/transcript/types.go internal/transcript/parse.go internal/transcript/parse_test.go
+git commit -m "feat: add transcript JSONL parser with delta extraction and mechanical facts"
+```
+
+---
+
+### Task 5: Summarizer Backend Interface and Anthropic Implementation
+
+**Files:**
+- Create: `internal/checkpoint/summarizer.go`
+- Create: `internal/checkpoint/config.go`
+- Create: `internal/checkpoint/noop.go`
+- Create: `internal/checkpoint/anthropic.go`
+- Create: `internal/checkpoint/anthropic_test.go`
+
+- [ ] **Step 1: Define the summarizer interface and config**
+
+Create `internal/checkpoint/summarizer.go`:
+
+```go
+package checkpoint
+
+import "context"
+
+// SummarizeInput is what the worker sends to the summarizer.
+type SummarizeInput struct {
+    SemanticText string // filtered user/assistant transcript delta
+    FeatureTitle string // for context
+    Reason       string // stop, precompact, manual_checkpoint, manual_end_session
+}
+
+// SummarizeOutput is what the summarizer returns.
+type SummarizeOutput struct {
+    Summary   string   // human-readable narrative
+    Blockers  []string // discovered blockers
+    DeadEnds  []string // things tried that didn't work
+    NextSteps []string // intent for next session
+    Decisions []string // decisions discussed
+    Gotchas   []string // non-obvious discoveries
+}
+
+// SummarizerBackend processes transcript deltas into structured observations.
+type SummarizerBackend interface {
+    Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error)
+}
+```
+
+Create `internal/checkpoint/config.go`:
+
+```go
+package checkpoint
+
+import "os"
+
+const defaultModel = "claude-haiku-4-5-20251001"
+
+// Config holds summarizer configuration from environment variables.
+type Config struct {
+    APIKey  string
+    Model   string
+    Enabled bool
+}
+
+// LoadConfig reads summarizer configuration from environment variables.
+func LoadConfig() Config {
+    apiKey := os.Getenv("ANTHROPIC_API_KEY")
+    model := os.Getenv("DOCKET_SUMMARIZER_MODEL")
+    if model == "" {
+        model = defaultModel
+    }
+
+    enabled := apiKey != ""
+    if v := os.Getenv("DOCKET_SUMMARIZER_ENABLED"); v == "false" {
+        enabled = false
+    }
+
+    return Config{
+        APIKey:  apiKey,
+        Model:   model,
+        Enabled: enabled,
+    }
+}
+```
+
+Create `internal/checkpoint/noop.go`:
+
+```go
+package checkpoint
+
+import "context"
+
+// NoopSummarizer returns empty output. Used when no API key is configured.
+type NoopSummarizer struct{}
+
+func (n *NoopSummarizer) Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error) {
+    return &SummarizeOutput{}, nil
+}
+```
+
+- [ ] **Step 2: Write failing test for Anthropic summarizer**
+
+Create `internal/checkpoint/anthropic_test.go`:
+
+```go
+package checkpoint
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestAnthropicSummarizer(t *testing.T) {
+    // Mock Anthropic API server
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // Verify request
+        if r.Header.Get("x-api-key") != "test-key" {
+            t.Errorf("missing api key header")
+        }
+        if r.Header.Get("anthropic-version") == "" {
+            t.Errorf("missing anthropic-version header")
+        }
+
+        resp := map[string]any{
+            "content": []map[string]any{
+                {
+                    "type": "text",
+                    "text": `{"summary":"Discussed auth token refresh design. Decided on rotating tokens.","blockers":[],"dead_ends":["Tried stateless refresh but abandoned due to revocation complexity"],"next_steps":["Implement token rotation endpoint"],"decisions":["Use rotating refresh tokens"],"gotchas":["Token expiry must be checked server-side"]}`,
+                },
+            },
+        }
+        w.Header().Set("Content-Type", "application/json")
+        json.NewEncoder(w).Encode(resp)
+    }))
+    defer srv.Close()
+
+    s := &AnthropicSummarizer{
+        apiKey:  "test-key",
+        model:   "claude-haiku-4-5-20251001",
+        baseURL: srv.URL,
+    }
+
+    out, err := s.Summarize(context.Background(), SummarizeInput{
+        SemanticText: "User: How should we handle token refresh?\nAssistant: I recommend rotating refresh tokens...",
+        FeatureTitle: "Auth System",
+        Reason:       "stop",
+    })
+    if err != nil {
+        t.Fatalf("Summarize: %v", err)
+    }
+    if out.Summary == "" {
+        t.Error("expected non-empty summary")
+    }
+    if len(out.DeadEnds) != 1 {
+        t.Errorf("DeadEnds = %d, want 1", len(out.DeadEnds))
+    }
+    if len(out.Decisions) != 1 {
+        t.Errorf("Decisions = %d, want 1", len(out.Decisions))
+    }
+}
+
+func TestAnthropicSummarizerAPIError(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(500)
+        w.Write([]byte(`{"error":{"message":"internal error"}}`))
+    }))
+    defer srv.Close()
+
+    s := &AnthropicSummarizer{
+        apiKey:  "test-key",
+        model:   "claude-haiku-4-5-20251001",
+        baseURL: srv.URL,
+    }
+
+    _, err := s.Summarize(context.Background(), SummarizeInput{
+        SemanticText: "some text",
+        FeatureTitle: "Test",
+        Reason:       "stop",
+    })
+    if err == nil {
+        t.Fatal("expected error for 500 response")
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./internal/checkpoint/ -v -run TestAnthropicSummarizer`
+Expected: FAIL — `AnthropicSummarizer` not defined
+
+- [ ] **Step 4: Implement Anthropic summarizer**
+
+Create `internal/checkpoint/anthropic.go`:
+
+```go
+package checkpoint
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+)
+
+const defaultBaseURL = "https://api.anthropic.com"
+const anthropicVersion = "2023-06-01"
+
+// AnthropicSummarizer calls the Anthropic Messages API to summarize transcript deltas.
+type AnthropicSummarizer struct {
+    apiKey  string
+    model   string
+    baseURL string
+    client  *http.Client
+}
+
+// NewAnthropicSummarizer creates a summarizer using the Anthropic Messages API.
+func NewAnthropicSummarizer(cfg Config) *AnthropicSummarizer {
+    return &AnthropicSummarizer{
+        apiKey:  cfg.APIKey,
+        model:   cfg.Model,
+        baseURL: defaultBaseURL,
+        client:  &http.Client{},
+    }
+}
+
+type messagesRequest struct {
+    Model     string           `json:"model"`
+    MaxTokens int              `json:"max_tokens"`
+    System    string           `json:"system"`
+    Messages  []messageReq     `json:"messages"`
+}
+
+type messageReq struct {
+    Role    string `json:"role"`
+    Content string `json:"content"`
+}
+
+type messagesResponse struct {
+    Content []contentResp `json:"content"`
+    Error   *apiError     `json:"error"`
+}
+
+type contentResp struct {
+    Type string `json:"type"`
+    Text string `json:"text"`
+}
+
+type apiError struct {
+    Message string `json:"message"`
+}
+
+func (s *AnthropicSummarizer) Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error) {
+    systemPrompt := `You are a session context extractor for a software development feature tracker. Given a conversation excerpt between a developer and an AI assistant, extract structured information about what happened.
+
+Respond with ONLY a JSON object (no markdown, no explanation) with these fields:
+- "summary": 2-4 sentence narrative of what was discussed and accomplished
+- "blockers": array of strings — anything blocking progress
+- "dead_ends": array of strings — approaches tried that didn't work
+- "next_steps": array of strings — what should happen next
+- "decisions": array of strings — decisions made during the conversation
+- "gotchas": array of strings — non-obvious discoveries or warnings
+
+Use empty arrays for fields with no content. Be concise.`
+
+    userContent := fmt.Sprintf("Feature: %s\nCheckpoint reason: %s\n\nConversation excerpt:\n%s",
+        input.FeatureTitle, input.Reason, input.SemanticText)
+
+    // Truncate if too long (keep last part which is most relevant)
+    if len(userContent) > 30000 {
+        userContent = userContent[len(userContent)-30000:]
+    }
+
+    reqBody := messagesRequest{
+        Model:     s.model,
+        MaxTokens: 1024,
+        System:    systemPrompt,
+        Messages: []messageReq{
+            {Role: "user", Content: userContent},
+        },
+    }
+
+    body, err := json.Marshal(reqBody)
+    if err != nil {
+        return nil, fmt.Errorf("marshal request: %w", err)
+    }
+
+    req, err := http.NewRequestWithContext(ctx, "POST", s.baseURL+"/v1/messages", bytes.NewReader(body))
+    if err != nil {
+        return nil, fmt.Errorf("create request: %w", err)
+    }
+    req.Header.Set("Content-Type", "application/json")
+    req.Header.Set("x-api-key", s.apiKey)
+    req.Header.Set("anthropic-version", anthropicVersion)
+
+    resp, err := s.client.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("api call: %w", err)
+    }
+    defer resp.Body.Close()
+
+    respBody, err := io.ReadAll(resp.Body)
+    if err != nil {
+        return nil, fmt.Errorf("read response: %w", err)
+    }
+
+    if resp.StatusCode != 200 {
+        return nil, fmt.Errorf("api error (status %d): %s", resp.StatusCode, string(respBody))
+    }
+
+    var msgResp messagesResponse
+    if err := json.Unmarshal(respBody, &msgResp); err != nil {
+        return nil, fmt.Errorf("decode response: %w", err)
+    }
+
+    if len(msgResp.Content) == 0 {
+        return nil, fmt.Errorf("empty response content")
+    }
+
+    var output SummarizeOutput
+    if err := json.Unmarshal([]byte(msgResp.Content[0].Text), &output); err != nil {
+        // If JSON parsing fails, use raw text as summary
+        output.Summary = msgResp.Content[0].Text
+    }
+
+    return &output, nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/checkpoint/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/checkpoint/summarizer.go internal/checkpoint/config.go internal/checkpoint/noop.go internal/checkpoint/anthropic.go internal/checkpoint/anthropic_test.go
+git commit -m "feat: add summarizer backend interface with Anthropic Messages API implementation"
+```
+
+---
+
+### Task 6: Background Checkpoint Worker
+
+**Files:**
+- Create: `internal/checkpoint/worker.go`
+- Create: `internal/checkpoint/worker_test.go`
+
+- [ ] **Step 1: Write failing test for the worker**
+
+Create `internal/checkpoint/worker_test.go`:
+
+```go
+package checkpoint
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/sniffle6/claude-docket/internal/store"
+)
+
+type mockSummarizer struct {
+    calls   int
+    output  *SummarizeOutput
+    err     error
+}
+
+func (m *mockSummarizer) Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error) {
+    m.calls++
+    if m.err != nil {
+        return nil, m.err
+    }
+    if m.output != nil {
+        return m.output, nil
+    }
+    return &SummarizeOutput{
+        Summary:  "Test summary",
+        Blockers: []string{},
+    }, nil
+}
+
+func TestWorkerProcessesJob(t *testing.T) {
+    s, err := store.Open(t.TempDir())
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer s.Close()
+
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    s.EnqueueCheckpointJob(store.CheckpointJobInput{
+        WorkSessionID:        ws.ID,
+        FeatureID:            "auth-system",
+        Reason:               "stop",
+        TranscriptStartOffset: 0,
+        TranscriptEndOffset:  512,
+        SemanticText:         "discussed auth design",
+        MechanicalFacts:      store.MechanicalFacts{},
+    })
+
+    mock := &mockSummarizer{}
+    w := NewWorker(s, mock)
+
+    // Process one job
+    processed := w.ProcessOne()
+    if !processed {
+        t.Fatal("expected to process a job")
+    }
+    if mock.calls != 1 {
+        t.Errorf("summarizer calls = %d, want 1", mock.calls)
+    }
+
+    // Verify observation was written
+    obs, _ := s.GetObservationsForWorkSession(ws.ID)
+    if len(obs) == 0 {
+        t.Fatal("expected at least one observation")
+    }
+    if obs[0].Kind != "summary" {
+        t.Errorf("Kind = %q, want %q", obs[0].Kind, "summary")
+    }
+}
+
+func TestWorkerSkipsNoopOnEmptyText(t *testing.T) {
+    s, err := store.Open(t.TempDir())
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer s.Close()
+
+    s.AddFeature("Auth System", "token auth")
+    ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+    s.EnqueueCheckpointJob(store.CheckpointJobInput{
+        WorkSessionID:        ws.ID,
+        FeatureID:            "auth-system",
+        Reason:               "stop",
+        TranscriptStartOffset: 0,
+        TranscriptEndOffset:  512,
+        SemanticText:         "", // empty
+        MechanicalFacts:      store.MechanicalFacts{FilesEdited: []store.FileEdit{{Path: "a.go", Count: 1}}},
+    })
+
+    mock := &mockSummarizer{}
+    w := NewWorker(s, mock)
+    w.ProcessOne()
+
+    // Should skip LLM call but still mark as done
+    if mock.calls != 0 {
+        t.Errorf("expected 0 summarizer calls for empty text, got %d", mock.calls)
+    }
+
+    job, _ := s.GetCheckpointJob(1)
+    if job.Status != "done" {
+        t.Errorf("Status = %q, want done (skipped)", job.Status)
+    }
+}
+
+func TestWorkerRunLoop(t *testing.T) {
+    s, err := store.Open(t.TempDir())
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer s.Close()
+
+    mock := &mockSummarizer{}
+    w := NewWorker(s, mock)
+
+    ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+    defer cancel()
+
+    // Run should exit when context is cancelled
+    w.Run(ctx, 50*time.Millisecond)
+    // No panic = pass
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/checkpoint/ -v -run TestWorker`
+Expected: FAIL — `NewWorker` not defined
+
+- [ ] **Step 3: Implement the worker**
+
+Create `internal/checkpoint/worker.go`:
+
+```go
+package checkpoint
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "os"
+    "time"
+
+    "github.com/sniffle6/claude-docket/internal/store"
+)
+
+// Worker drains checkpoint_jobs and calls the summarizer for each.
+type Worker struct {
+    store      *store.Store
+    summarizer SummarizerBackend
+}
+
+func NewWorker(s *store.Store, summarizer SummarizerBackend) *Worker {
+    return &Worker{store: s, summarizer: summarizer}
+}
+
+// Run polls for queued jobs and processes them until ctx is cancelled.
+func (w *Worker) Run(ctx context.Context, pollInterval time.Duration) {
+    ticker := time.NewTicker(pollInterval)
+    defer ticker.Stop()
+
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-ticker.C:
+            for w.ProcessOne() {
+                // drain all queued jobs before waiting
+            }
+        }
+    }
+}
+
+// ProcessOne dequeues and processes a single checkpoint job.
+// Returns true if a job was processed, false if the queue was empty.
+func (w *Worker) ProcessOne() bool {
+    job, err := w.store.DequeueCheckpointJob()
+    if err != nil || job == nil {
+        return false
+    }
+
+    // Get feature title for context
+    featureTitle := job.FeatureID
+    if f, err := w.store.GetFeature(job.FeatureID); err == nil {
+        featureTitle = f.Title
+    }
+
+    // If semantic text is empty, skip LLM call but still mark done
+    if job.SemanticText == "" {
+        w.store.CompleteCheckpointJob(job.ID, nil)
+        return true
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    output, err := w.summarizer.Summarize(ctx, SummarizeInput{
+        SemanticText: job.SemanticText,
+        FeatureTitle: featureTitle,
+        Reason:       job.Reason,
+    })
+    if err != nil {
+        errMsg := err.Error()
+        w.store.FailCheckpointJob(job.ID, errMsg)
+        fmt.Fprintf(os.Stderr, "docket checkpoint worker: summarize job %d: %v\n", job.ID, err)
+        return true
+    }
+
+    // Write observations
+    w.writeObservations(job, output)
+    w.store.CompleteCheckpointJob(job.ID, nil)
+
+    // Auto-merge key_files from mechanical facts
+    w.mergeKeyFiles(job)
+
+    return true
+}
+
+func (w *Worker) writeObservations(job *store.CheckpointJob, output *SummarizeOutput) {
+    if output.Summary != "" {
+        payload, _ := json.Marshal(output)
+        w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+            CheckpointJobID: job.ID,
+            WorkSessionID:   job.WorkSessionID,
+            FeatureID:       job.FeatureID,
+            Kind:            "summary",
+            PayloadJSON:     string(payload),
+            SummaryText:     output.Summary,
+        })
+    }
+    for _, b := range output.Blockers {
+        w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+            CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+            FeatureID: job.FeatureID, Kind: "blocker", SummaryText: b,
+        })
+    }
+    for _, d := range output.DeadEnds {
+        w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+            CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+            FeatureID: job.FeatureID, Kind: "dead_end", SummaryText: d,
+        })
+    }
+    for _, n := range output.NextSteps {
+        w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+            CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+            FeatureID: job.FeatureID, Kind: "next_step", SummaryText: n,
+        })
+    }
+    for _, d := range output.Decisions {
+        w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+            CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+            FeatureID: job.FeatureID, Kind: "decision_candidate", SummaryText: d,
+        })
+    }
+    for _, g := range output.Gotchas {
+        w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+            CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+            FeatureID: job.FeatureID, Kind: "gotcha", SummaryText: g,
+        })
+    }
+}
+
+func (w *Worker) mergeKeyFiles(job *store.CheckpointJob) {
+    var facts store.MechanicalFacts
+    if err := json.Unmarshal([]byte(job.MechanicalJSON), &facts); err != nil || len(facts.FilesEdited) == 0 {
+        return
+    }
+
+    feature, err := w.store.GetFeature(job.FeatureID)
+    if err != nil {
+        return
+    }
+
+    existing := make(map[string]bool, len(feature.KeyFiles))
+    for _, f := range feature.KeyFiles {
+        existing[f] = true
+    }
+
+    merged := append([]string{}, feature.KeyFiles...)
+    changed := false
+    for _, fe := range facts.FilesEdited {
+        if !existing[fe.Path] {
+            merged = append(merged, fe.Path)
+            existing[fe.Path] = true
+            changed = true
+        }
+    }
+
+    if changed {
+        w.store.UpdateFeature(job.FeatureID, store.FeatureUpdate{KeyFiles: &merged})
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/checkpoint/ -v -run TestWorker`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/checkpoint/worker.go internal/checkpoint/worker_test.go
+git commit -m "feat: add background checkpoint worker — drains job queue, calls summarizer, writes observations"
+```
+
+---
+
+### Task 7: Rewrite Hook Handlers
+
+**Files:**
+- Modify: `cmd/docket/hook.go`
+- Modify: `cmd/docket/hook_test.go`
+
+This is the largest task. It rewrites Stop, adds PreCompact and SessionEnd, and updates SessionStart to open work sessions.
+
+- [ ] **Step 1: Update hookInput struct**
+
+In `cmd/docket/hook.go`, update the `hookInput` struct to add `TranscriptPath`:
+
+```go
+type hookInput struct {
+    SessionID      string    `json:"session_id"`
+    TranscriptPath string    `json:"transcript_path"`
+    CWD            string    `json:"cwd"`
+    HookEventName  string    `json:"hook_event_name"`
+    ToolName       string    `json:"tool_name"`
+    ToolInput      toolInput `json:"tool_input"`
+    StopHookActive bool      `json:"stop_hook_active"`
+    Trigger        string    `json:"trigger"` // PreCompact: "manual" or "auto"
+}
+```
+
+- [ ] **Step 2: Update handleSessionStart to open work sessions**
+
+Replace the `handleSessionStart` function. The new version opens a work session for the top active feature:
+
+```go
+func handleSessionStart(h *hookInput, w io.Writer) {
+    s, err := store.Open(h.CWD)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "docket hook: open store: %v\n", err)
+        json.NewEncoder(w).Encode(hookOutput{Continue: true})
+        return
+    }
+    defer s.Close()
+
+    // Auto-archive features done >7 days
+    var archiveMsg string
+    if archived, err := s.AutoArchiveStale(); err == nil && len(archived) > 0 {
+        archiveMsg = fmt.Sprintf("[docket] Auto-archived %d features done >7 days: %s\n", len(archived), strings.Join(archived, ", "))
+    }
+
+    // Create/clear commits.log
+    commitsPath := filepath.Join(h.CWD, ".docket", "commits.log")
+    os.WriteFile(commitsPath, []byte{}, 0644)
+
+    // Clear agent-nudged sentinel for new session
+    sentinelPath := filepath.Join(h.CWD, ".docket", "agent-nudged")
+    os.Remove(sentinelPath)
+
+    // Reset transcript offset for new session
+    offsetPath := filepath.Join(h.CWD, ".docket", "transcript-offset")
+    os.WriteFile(offsetPath, []byte("0"), 0644)
+
+    features, err := s.ListFeatures("in_progress")
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "docket hook: list features: %v\n", err)
+        json.NewEncoder(w).Encode(hookOutput{Continue: true})
+        return
+    }
+
+    out := hookOutput{Continue: true}
+
+    if len(features) == 0 {
+        out.SystemMessage = archiveMsg + "[docket] No active features. Use docket MCP tools to create one."
+        json.NewEncoder(w).Encode(out)
+        return
+    }
+
+    // Open work session for top feature
+    topFeature := features[0]
+    s.OpenWorkSession(topFeature.ID, h.SessionID)
+
+    var msg strings.Builder
+    handoffPath := filepath.Join(h.CWD, ".docket", "handoff", topFeature.ID+".md")
+
+    if content, err := os.ReadFile(handoffPath); err == nil {
+        msg.WriteString("[docket] Session context:\n\n")
+        msg.Write(content)
+    } else {
+        // Fallback: list features with left_off and next task
+        msg.WriteString("[docket] Active features:\n")
+        msg.WriteString(fmt.Sprintf("- %s (id: %s)", topFeature.Title, topFeature.ID))
+        if topFeature.LeftOff != "" {
+            msg.WriteString(fmt.Sprintf(" — left off: %s", topFeature.LeftOff))
+        }
+        msg.WriteString("\n")
+
+        subtasks, err := s.GetSubtasksForFeature(topFeature.ID, false)
+        if err == nil {
+            for _, st := range subtasks {
+                for _, item := range st.Items {
+                    if !item.Checked {
+                        msg.WriteString(fmt.Sprintf("Next task: %s\n", item.Title))
+                        goto doneNextTask
+                    }
+                }
+            }
+        }
+    doneNextTask:
+    }
+
+    // Other features: pointers or one-liners
+    for _, f := range features[1:] {
+        otherHandoff := filepath.Join(h.CWD, ".docket", "handoff", f.ID+".md")
+        if _, err := os.Stat(otherHandoff); err == nil {
+            msg.WriteString(fmt.Sprintf("\n[docket] Handoff available: .docket/handoff/%s.md", f.ID))
+        } else {
+            msg.WriteString(fmt.Sprintf("\n[docket] Also active: %s (id: %s)", f.Title, f.ID))
+        }
+    }
+
+    out.SystemMessage = archiveMsg + msg.String()
+    json.NewEncoder(w).Encode(out)
+}
+```
+
+- [ ] **Step 3: Rewrite handleStop — single-phase, enqueue checkpoint**
+
+Replace the entire `handleStop` function:
+
+```go
+func handleStop(h *hookInput, w io.Writer) {
+    s, err := store.Open(h.CWD)
+    if err != nil {
+        json.NewEncoder(w).Encode(stopHookOutput{})
+        return
+    }
+    defer s.Close()
+
+    ws, err := s.GetActiveWorkSession()
+    if err != nil {
+        // No active work session — allow stop
+        json.NewEncoder(w).Encode(stopHookOutput{})
+        return
+    }
+
+    // Parse transcript delta
+    delta := parseTranscriptDelta(h)
+
+    // Check meaningful delta threshold
+    if !isDeltaMeaningful(h.CWD, delta) {
+        json.NewEncoder(w).Encode(stopHookOutput{})
+        return
+    }
+
+    // Enqueue checkpoint job
+    s.EnqueueCheckpointJob(store.CheckpointJobInput{
+        WorkSessionID:         ws.ID,
+        FeatureID:             ws.FeatureID,
+        Reason:                "stop",
+        TriggerType:           "auto",
+        TranscriptStartOffset: getTranscriptOffset(h.CWD),
+        TranscriptEndOffset:   delta.EndOffset,
+        SemanticText:          delta.SemanticText,
+        MechanicalFacts:       delta.MechanicalFacts,
+    })
+
+    // Update transcript offset
+    saveTranscriptOffset(h.CWD, delta.EndOffset)
+
+    // Never block — always allow stop
+    json.NewEncoder(w).Encode(stopHookOutput{})
+}
+```
+
+- [ ] **Step 4: Add handlePreCompact**
+
+Add the new `handlePreCompact` handler:
+
+```go
+func handlePreCompact(h *hookInput, w io.Writer) {
+    s, err := store.Open(h.CWD)
+    if err != nil {
+        json.NewEncoder(w).Encode(hookOutput{Continue: true})
+        return
+    }
+    defer s.Close()
+
+    ws, err := s.GetActiveWorkSession()
+    if err != nil {
+        json.NewEncoder(w).Encode(hookOutput{Continue: true})
+        return
+    }
+
+    // Force checkpoint — PreCompact always enqueues regardless of threshold
+    delta := parseTranscriptDelta(h)
+    startOffset := getTranscriptOffset(h.CWD)
+
+    s.EnqueueCheckpointJob(store.CheckpointJobInput{
+        WorkSessionID:         ws.ID,
+        FeatureID:             ws.FeatureID,
+        Reason:                "precompact",
+        TriggerType:           h.Trigger,
+        TranscriptStartOffset: startOffset,
+        TranscriptEndOffset:   delta.EndOffset,
+        SemanticText:          delta.SemanticText,
+        MechanicalFacts:       delta.MechanicalFacts,
+    })
+
+    saveTranscriptOffset(h.CWD, delta.EndOffset)
+
+    json.NewEncoder(w).Encode(hookOutput{Continue: true})
+}
+```
+
+- [ ] **Step 5: Add handleSessionEnd**
+
+Add the new `handleSessionEnd` handler:
+
+```go
+func handleSessionEnd(h *hookInput, w io.Writer) {
+    s, err := store.Open(h.CWD)
+    if err != nil {
+        json.NewEncoder(w).Encode(stopHookOutput{})
+        return
+    }
+    defer s.Close()
+
+    ws, err := s.GetActiveWorkSession()
+    if err != nil {
+        json.NewEncoder(w).Encode(stopHookOutput{})
+        return
+    }
+
+    // Final cheap flush: enqueue any remaining delta
+    delta := parseTranscriptDelta(h)
+    if delta.HasContent {
+        s.EnqueueCheckpointJob(store.CheckpointJobInput{
+            WorkSessionID:         ws.ID,
+            FeatureID:             ws.FeatureID,
+            Reason:                "stop",
+            TriggerType:           "auto",
+            TranscriptStartOffset: getTranscriptOffset(h.CWD),
+            TranscriptEndOffset:   delta.EndOffset,
+            SemanticText:          delta.SemanticText,
+            MechanicalFacts:       delta.MechanicalFacts,
+        })
+    }
+
+    // Write handoff files for all active features
+    features, _ := s.ListFeatures("in_progress")
+    if len(features) > 0 {
+        activeIDs := make(map[string]bool)
+        for _, f := range features {
+            activeIDs[f.ID] = true
+            data, err := s.GetHandoffData(f.ID)
+            if err == nil {
+                if writeErr := writeHandoffFile(h.CWD, data); writeErr != nil {
+                    s.MarkHandoffStale(ws.ID)
+                }
+            }
+        }
+        cleanStaleHandoffs(h.CWD, activeIDs)
+    }
+
+    // Clean up commits.log
+    commitsPath := filepath.Join(h.CWD, ".docket", "commits.log")
+    os.Remove(commitsPath)
+
+    // Close work session
+    s.CloseWorkSession(ws.ID)
+
+    json.NewEncoder(w).Encode(stopHookOutput{})
+}
+```
+
+- [ ] **Step 6: Add helper functions for transcript offset and delta parsing**
+
+Add these helpers to `cmd/docket/hook.go`:
+
+```go
+func parseTranscriptDelta(h *hookInput) *transcript.Delta {
+    if h.TranscriptPath == "" {
+        return &transcript.Delta{}
+    }
+    offset := getTranscriptOffset(h.CWD)
+    delta, err := transcript.Parse(h.TranscriptPath, offset)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "docket hook: parse transcript: %v\n", err)
+        return &transcript.Delta{EndOffset: offset}
+    }
+    return delta
+}
+
+func getTranscriptOffset(cwd string) int64 {
+    data, err := os.ReadFile(filepath.Join(cwd, ".docket", "transcript-offset"))
+    if err != nil {
+        return 0
+    }
+    var offset int64
+    fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &offset)
+    return offset
+}
+
+func saveTranscriptOffset(cwd string, offset int64) {
+    os.WriteFile(
+        filepath.Join(cwd, ".docket", "transcript-offset"),
+        []byte(fmt.Sprintf("%d", offset)),
+        0644,
+    )
+}
+
+func isDeltaMeaningful(cwd string, delta *transcript.Delta) bool {
+    // Any commits in commits.log?
+    commitsPath := filepath.Join(cwd, ".docket", "commits.log")
+    if data, err := os.ReadFile(commitsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+        return true
+    }
+
+    // Transcript-detected commits or failures?
+    if len(delta.MechanicalFacts.Commits) > 0 {
+        return true
+    }
+    if len(delta.MechanicalFacts.Errors) > 0 {
+        return true
+    }
+    for _, tr := range delta.MechanicalFacts.TestRuns {
+        if !tr.Passed {
+            return true
+        }
+    }
+
+    // Semantic text threshold
+    if len(delta.SemanticText) >= 300 {
+        return true
+    }
+
+    // Non-trivial user input
+    if delta.HasContent {
+        return true
+    }
+
+    return false
+}
+```
+
+- [ ] **Step 7: Update the switch statement in runHook() to route new events**
+
+Update the switch in `runHook()`:
+
+```go
+switch h.HookEventName {
+case "PreToolUse":
+    handlePreToolUse(&h, os.Stdout)
+case "SessionStart":
+    handleSessionStart(&h, os.Stdout)
+case "PostToolUse":
+    handlePostToolUse(&h, os.Stdout)
+case "Stop":
+    handleStop(&h, os.Stdout)
+case "PreCompact":
+    handlePreCompact(&h, os.Stdout)
+case "SessionEnd":
+    handleSessionEnd(&h, os.Stdout)
+default:
+    json.NewEncoder(os.Stdout).Encode(hookOutput{Continue: true})
+}
+```
+
+- [ ] **Step 8: Add the import for the transcript package**
+
+Add `"github.com/sniffle6/claude-docket/internal/transcript"` to the imports in `hook.go`.
+
+- [ ] **Step 9: Write tests for the new hook behavior**
+
+Add to `cmd/docket/hook_test.go`:
+
+```go
+func TestStopNeverBlocks(t *testing.T) {
+    dir := t.TempDir()
+    s, _ := store.Open(dir)
+    s.AddFeature("Test Feature", "test")
+    s.UpdateFeature("test-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+    s.OpenWorkSession("test-feature", "sess-1")
+
+    // Write a commit to commits.log
+    commitsPath := filepath.Join(dir, ".docket", "commits.log")
+    os.WriteFile(commitsPath, []byte("abc123|||fix bug\n"), 0644)
+
+    // Write transcript offset
+    os.WriteFile(filepath.Join(dir, ".docket", "transcript-offset"), []byte("0"), 0644)
+
+    s.Close()
+
+    h := &hookInput{
+        SessionID:     "sess-1",
+        CWD:           dir,
+        HookEventName: "Stop",
+    }
+
+    var buf bytes.Buffer
+    handleStop(h, &buf)
+
+    var out stopHookOutput
+    json.Unmarshal(buf.Bytes(), &out)
+
+    // Must never block
+    if out.Decision == "block" {
+        t.Error("Stop hook must never block")
+    }
+}
+
+func TestSessionEndClosesWorkSession(t *testing.T) {
+    dir := t.TempDir()
+    s, _ := store.Open(dir)
+    s.AddFeature("Test Feature", "test")
+    s.UpdateFeature("test-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+    s.OpenWorkSession("test-feature", "sess-1")
+    s.Close()
+
+    h := &hookInput{
+        SessionID:     "sess-1",
+        CWD:           dir,
+        HookEventName: "SessionEnd",
+    }
+
+    var buf bytes.Buffer
+    handleSessionEnd(h, &buf)
+
+    // Verify work session is closed
+    s2, _ := store.Open(dir)
+    defer s2.Close()
+    _, err := s2.GetActiveWorkSession()
+    if err == nil {
+        t.Error("expected no active work session after SessionEnd")
+    }
+}
+
+func TestSessionStartOpensWorkSession(t *testing.T) {
+    dir := t.TempDir()
+    s, _ := store.Open(dir)
+    s.AddFeature("Test Feature", "test")
+    s.UpdateFeature("test-feature", store.FeatureUpdate{Status: strPtr("in_progress")})
+    s.Close()
+
+    h := &hookInput{
+        SessionID:     "sess-1",
+        CWD:           dir,
+        HookEventName: "SessionStart",
+    }
+
+    var buf bytes.Buffer
+    handleSessionStart(h, &buf)
+
+    // Verify work session was opened
+    s2, _ := store.Open(dir)
+    defer s2.Close()
+    ws, err := s2.GetActiveWorkSession()
+    if err != nil {
+        t.Fatalf("expected active work session, got error: %v", err)
+    }
+    if ws.FeatureID != "test-feature" {
+        t.Errorf("FeatureID = %q, want %q", ws.FeatureID, "test-feature")
+    }
+}
+```
+
+- [ ] **Step 10: Run all hook tests**
+
+Run: `go test ./cmd/docket/ -v -run "TestStop|TestSessionEnd|TestSessionStart"`
+Expected: PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add cmd/docket/hook.go cmd/docket/hook_test.go
+git commit -m "feat: rewrite hook handlers — single-phase stop, PreCompact, SessionEnd, work sessions"
+```
+
+---
+
+### Task 8: Remove log_session and Sentinel Logic
+
+**Files:**
+- Modify: `internal/mcp/tools.go:49-55` — remove `log_session` registration
+- Modify: `internal/mcp/tools_session.go` — remove `logSessionHandler`
+- Modify: `internal/store/store.go:125-140` — remove sentinel methods
+- Modify: `internal/mcp/tools_test.go` — remove/update log_session tests
+
+- [ ] **Step 1: Remove log_session tool registration from tools.go**
+
+In `internal/mcp/tools.go`, delete lines 49-55 (the `log_session` tool registration block).
+
+- [ ] **Step 2: Remove logSessionHandler from tools_session.go**
+
+In `internal/mcp/tools_session.go`, delete the `logSessionHandler` function (lines 14-58). Keep `compactSessionsHandler`.
+
+- [ ] **Step 3: Remove sentinel methods from store.go**
+
+In `internal/store/store.go`, delete `MarkSessionLogged`, `WasSessionLogged`, and `ClearSessionLogged` (lines 125-140).
+
+- [ ] **Step 4: Update any tests that reference log_session or sentinel methods**
+
+Search for and update tests in `internal/mcp/tools_test.go` that call `log_session`. Remove those test cases.
+
+Run: `grep -n "log_session\|MarkSessionLogged\|WasSessionLogged\|ClearSessionLogged\|session-logged" cmd/docket/hook.go internal/mcp/tools_test.go`
+
+Remove or update all references found.
+
+- [ ] **Step 5: Run all tests to verify nothing breaks**
+
+Run: `go test ./...`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/mcp/tools.go internal/mcp/tools_session.go internal/store/store.go internal/mcp/tools_test.go cmd/docket/hook.go
+git commit -m "feat: remove log_session MCP tool and session-logged sentinel"
+```
+
+---
+
+### Task 9: Add checkpoint MCP Tool
+
+**Files:**
+- Modify: `internal/mcp/tools.go` — add `checkpoint` tool registration
+- Create: `internal/mcp/tools_checkpoint.go` — handler
+
+- [ ] **Step 1: Write the handler**
+
+Create `internal/mcp/tools_checkpoint.go`:
+
+```go
+package mcp
+
+import (
+    "context"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "github.com/mark3labs/mcp-go/mcp"
+    "github.com/mark3labs/mcp-go/server"
+
+    "github.com/sniffle6/claude-docket/internal/store"
+    "github.com/sniffle6/claude-docket/internal/transcript"
+)
+
+func checkpointHandler(s *store.Store, projectDir string) server.ToolHandlerFunc {
+    return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+        args := req.GetArguments()
+        endSession := false
+        if v, ok := args["end_session"]; ok {
+            if b, ok := v.(bool); ok {
+                endSession = b
+            }
+        }
+
+        ws, err := s.GetActiveWorkSession()
+        if err != nil {
+            return mcp.NewToolResultError("no active work session — nothing to checkpoint"), nil
+        }
+
+        // Read transcript offset
+        offsetPath := filepath.Join(projectDir, ".docket", "transcript-offset")
+        var startOffset int64
+        if data, err := os.ReadFile(offsetPath); err == nil {
+            fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &startOffset)
+        }
+
+        // Find transcript path — check common locations
+        transcriptPath := findTranscriptPath(ws.ClaudeSessionID)
+        if transcriptPath == "" {
+            return mcp.NewToolResultText("Checkpoint enqueued (mechanical only — transcript not found)."), nil
+        }
+
+        delta, err := transcript.Parse(transcriptPath, startOffset)
+        if err != nil {
+            return mcp.NewToolResultError(fmt.Sprintf("parse transcript: %v", err)), nil
+        }
+
+        reason := "manual_checkpoint"
+        if endSession {
+            reason = "manual_end_session"
+        }
+
+        job, err := s.EnqueueCheckpointJob(store.CheckpointJobInput{
+            WorkSessionID:         ws.ID,
+            FeatureID:             ws.FeatureID,
+            Reason:                reason,
+            TriggerType:           "manual",
+            TranscriptStartOffset: startOffset,
+            TranscriptEndOffset:   delta.EndOffset,
+            SemanticText:          delta.SemanticText,
+            MechanicalFacts:       delta.MechanicalFacts,
+        })
+        if err != nil {
+            return mcp.NewToolResultError(fmt.Sprintf("enqueue checkpoint: %v", err)), nil
+        }
+
+        // Update offset
+        os.WriteFile(offsetPath, []byte(fmt.Sprintf("%d", delta.EndOffset)), 0644)
+
+        // If ending session, write handoff and close work session
+        if endSession {
+            data, err := s.GetHandoffData(ws.FeatureID)
+            if err == nil {
+                obs, _ := s.GetObservationsForWorkSession(ws.ID)
+                mf, _ := s.GetMechanicalFactsForWorkSession(ws.ID)
+                // Write handoff inline since we have the data
+                writeHandoffFileWithCheckpointsFromMCP(projectDir, data, obs, mf)
+            }
+            s.CloseWorkSession(ws.ID)
+
+            return mcp.NewToolResultText(fmt.Sprintf(
+                "Work session closed for feature %q. Checkpoint #%d enqueued. Handoff written.",
+                ws.FeatureID, job.ID,
+            )), nil
+        }
+
+        return mcp.NewToolResultText(fmt.Sprintf(
+            "Checkpoint #%d enqueued for feature %q. %d chars semantic text, %d files edited.",
+            job.ID, ws.FeatureID, len(delta.SemanticText), len(delta.MechanicalFacts.FilesEdited),
+        )), nil
+    }
+}
+
+func findTranscriptPath(claudeSessionID string) string {
+    if claudeSessionID == "" {
+        return ""
+    }
+    // Claude stores transcripts in ~/.claude/projects/<hash>/<session-id>.jsonl
+    home, err := os.UserHomeDir()
+    if err != nil {
+        return ""
+    }
+    projectsDir := filepath.Join(home, ".claude", "projects")
+    entries, err := os.ReadDir(projectsDir)
+    if err != nil {
+        return ""
+    }
+    for _, entry := range entries {
+        if !entry.IsDir() {
+            continue
+        }
+        candidate := filepath.Join(projectsDir, entry.Name(), claudeSessionID+".jsonl")
+        if _, err := os.Stat(candidate); err == nil {
+            return candidate
+        }
+    }
+    return ""
+}
+```
+
+- [ ] **Step 2: Register the checkpoint tool**
+
+In `internal/mcp/tools.go`, add after the `compact_sessions` registration (around line 70):
+
+```go
+srv.AddTool(mcp.NewTool("checkpoint",
+    mcp.WithDescription("Force a checkpoint of the current session's semantic and mechanical state. Enqueues a background summarization job. Pass end_session=true to also close the work session and write the handoff file."),
+    mcp.WithBoolean("end_session", mcp.Description("If true, close the work session and write handoff after checkpointing. Default: false.")),
+), checkpointHandler(s, projectDir))
+```
+
+Note: `registerTools` will need a `projectDir` parameter. Update the signature:
+
+```go
+func registerTools(srv *server.MCPServer, s *store.Store, projectDir string) {
+```
+
+And update the caller in `NewServer`.
+
+- [ ] **Step 3: Update NewServer to pass projectDir**
+
+In `internal/mcp/tools.go`, update `NewServer` to accept and pass `projectDir`. Check how it's currently called and update the call site in `cmd/docket/main.go`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./...`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcp/tools.go internal/mcp/tools_checkpoint.go cmd/docket/main.go
+git commit -m "feat: add checkpoint MCP tool for manual context preservation"
+```
+
+---
+
+### Task 10: Start Checkpoint Worker in MCP Server
+
+**Files:**
+- Modify: `cmd/docket/main.go:71-103`
+
+- [ ] **Step 1: Update runServe to start the checkpoint worker**
+
+In `cmd/docket/main.go`, update `runServe()` to start the background worker:
+
+```go
+func runServe() {
+    dir, err := os.Getwd()
+    if err != nil {
+        log.Fatalf("getwd: %v", err)
+    }
+    s, err := store.Open(dir)
+    if err != nil {
+        log.Fatalf("open store: %v", err)
+    }
+    defer s.Close()
+
+    // Start HTTP dashboard in background on a per-project port
+    port := portForDir(dir)
+
+    // Write port file so skills/tools can discover the dashboard URL
+    portFile := filepath.Join(dir, ".docket", "port")
+    os.WriteFile(portFile, []byte(fmt.Sprintf("%d", port)), 0644)
+
+    go func() {
+        handler := dashboard.NewHandler(s, staticfiles.StaticFS, dir)
+        addr := fmt.Sprintf(":%d", port)
+        log.Printf("Dashboard: http://localhost:%d", port)
+        if err := http.ListenAndServe(addr, handler); err != nil {
+            log.Printf("dashboard error: %v", err)
+        }
+    }()
+
+    // Start checkpoint worker in background
+    cfg := checkpoint.LoadConfig()
+    var summarizer checkpoint.SummarizerBackend
+    if cfg.Enabled {
+        summarizer = checkpoint.NewAnthropicSummarizer(cfg)
+        log.Printf("Checkpoint summarizer: enabled (model: %s)", cfg.Model)
+    } else {
+        summarizer = &checkpoint.NoopSummarizer{}
+        log.Printf("Checkpoint summarizer: disabled (no ANTHROPIC_API_KEY)")
+    }
+
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+
+    worker := checkpoint.NewWorker(s, summarizer)
+    go worker.Run(ctx, 5*time.Second)
+
+    // Run MCP server on stdio (blocks)
+    mcpServer := docketmcp.NewServer(s, dir)
+    if err := server.ServeStdio(mcpServer); err != nil {
+        log.Fatalf("mcp server: %v", err)
+    }
+}
+```
+
+Add the necessary imports: `"context"`, `"time"`, `"github.com/sniffle6/claude-docket/internal/checkpoint"`.
+
+- [ ] **Step 2: Run build to verify compilation**
+
+Run: `go build -o /dev/null ./cmd/docket/`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/docket/main.go
+git commit -m "feat: start checkpoint worker in MCP server process"
+```
+
+---
+
+### Task 11: Update Handoff Renderer
+
+**Files:**
+- Modify: `cmd/docket/handoff.go`
+
+- [ ] **Step 1: Update renderHandoff to include checkpoint observations**
+
+Add a new "Last Session" section to the handoff renderer. The function needs access to the store to query observations. Update the signature and add the section:
+
+In `cmd/docket/handoff.go`, update `renderHandoff` to accept optional checkpoint data:
+
+```go
+type HandoffCheckpointData struct {
+    Observations    []store.CheckpointObservation
+    MechanicalFacts *store.MechanicalFacts
+}
+
+func renderHandoff(data *store.HandoffData, cpData *HandoffCheckpointData) string {
+    var b strings.Builder
+    f := data.Feature
+
+    fmt.Fprintf(&b, "# Handoff: %s\n\n", f.Title)
+
+    fmt.Fprintf(&b, "## Status\n")
+    fmt.Fprintf(&b, "%s | Progress: %d/%d | Updated: %s\n\n",
+        f.Status, data.Done, data.Total, f.UpdatedAt.Format("2006-01-02 15:04"))
+
+    if f.LeftOff != "" {
+        fmt.Fprintf(&b, "## Left Off\n%s\n\n", f.LeftOff)
+    }
+
+    // New: Last Session section from checkpoint observations
+    if cpData != nil && (len(cpData.Observations) > 0 || cpData.MechanicalFacts != nil) {
+        b.WriteString("## Last Session\n")
+
+        // Semantic observations
+        for _, obs := range cpData.Observations {
+            switch obs.Kind {
+            case "summary":
+                fmt.Fprintf(&b, "%s\n\n", obs.SummaryText)
+            case "blocker":
+                fmt.Fprintf(&b, "- **Blocker:** %s\n", obs.SummaryText)
+            case "dead_end":
+                fmt.Fprintf(&b, "- **Dead end:** %s\n", obs.SummaryText)
+            case "next_step":
+                fmt.Fprintf(&b, "- **Next:** %s\n", obs.SummaryText)
+            case "decision_candidate":
+                fmt.Fprintf(&b, "- **Decision:** %s\n", obs.SummaryText)
+            case "gotcha":
+                fmt.Fprintf(&b, "- **Gotcha:** %s\n", obs.SummaryText)
+            }
+        }
+
+        // Mechanical facts
+        if cpData.MechanicalFacts != nil {
+            mf := cpData.MechanicalFacts
+            if len(mf.FilesEdited) > 0 {
+                var parts []string
+                for _, fe := range mf.FilesEdited {
+                    if fe.Count > 1 {
+                        parts = append(parts, fmt.Sprintf("%s (%d×)", fe.Path, fe.Count))
+                    } else {
+                        parts = append(parts, fe.Path)
+                    }
+                }
+                fmt.Fprintf(&b, "\nFiles: %s\n", strings.Join(parts, ", "))
+            }
+            if len(mf.TestRuns) > 0 {
+                passed := 0
+                for _, tr := range mf.TestRuns {
+                    if tr.Passed {
+                        passed++
+                    }
+                }
+                fmt.Fprintf(&b, "Tests: %d runs (%d passed, %d failed)\n",
+                    len(mf.TestRuns), passed, len(mf.TestRuns)-passed)
+            }
+            if len(mf.Commits) > 0 {
+                var msgs []string
+                for _, c := range mf.Commits {
+                    msgs = append(msgs, fmt.Sprintf("%q", c.Message))
+                }
+                fmt.Fprintf(&b, "Commits: %s\n", strings.Join(msgs, ", "))
+            }
+        }
+        b.WriteString("\n")
+    }
+
+    if len(data.NextTasks) > 0 {
+        b.WriteString("## Next Tasks\n")
+        for _, task := range data.NextTasks {
+            fmt.Fprintf(&b, "- [ ] %s\n", task)
+        }
+        b.WriteString("\n")
+    }
+
+    if len(f.KeyFiles) > 0 {
+        b.WriteString("## Key Files\n")
+        for _, kf := range f.KeyFiles {
+            fmt.Fprintf(&b, "- %s\n", kf)
+        }
+        b.WriteString("\n")
+    }
+
+    if len(data.RecentSessions) > 0 {
+        b.WriteString("## Recent Activity\n")
+        for _, sess := range data.RecentSessions {
+            line := fmt.Sprintf("- %s: %s", sess.CreatedAt.Format("2006-01-02"), sess.Summary)
+            if len(sess.Commits) > 0 {
+                line += fmt.Sprintf(" [%s]", strings.Join(sess.Commits, ", "))
+            }
+            fmt.Fprintf(&b, "%s\n", line)
+        }
+        b.WriteString("\n")
+    }
+
+    if len(data.SubtaskSummary) > 0 {
+        b.WriteString("## Active Subtasks\n")
+        for _, st := range data.SubtaskSummary {
+            fmt.Fprintf(&b, "- %s [%d/%d]\n", st.Title, st.Done, st.Total)
+        }
+        b.WriteString("\n")
+    }
+
+    return b.String()
+}
+```
+
+- [ ] **Step 2: Update writeHandoffFile to load checkpoint data**
+
+Update `writeHandoffFile` to accept and use checkpoint data:
+
+```go
+func writeHandoffFile(dir string, data *store.HandoffData) error {
+    return writeHandoffFileWithCheckpoints(dir, data, nil)
+}
+
+func writeHandoffFileWithCheckpoints(dir string, data *store.HandoffData, cpData *HandoffCheckpointData) error {
+    handoffDir := filepath.Join(dir, ".docket", "handoff")
+    if err := os.MkdirAll(handoffDir, 0755); err != nil {
+        return err
+    }
+    path := filepath.Join(handoffDir, data.Feature.ID+".md")
+
+    baseline := renderHandoff(data, cpData)
+
+    // Preserve enrichment sections from board-manager if they exist
+    if existing, err := os.ReadFile(path); err == nil {
+        enrichment := extractEnrichmentSections(string(existing))
+        if enrichment != "" {
+            baseline = strings.TrimRight(baseline, "\n") + "\n" + enrichment
+        }
+    }
+
+    return os.WriteFile(path, []byte(baseline), 0644)
+}
+```
+
+- [ ] **Step 3: Update SessionEnd handler to pass checkpoint data**
+
+In `cmd/docket/hook.go`, update `handleSessionEnd` to query and pass checkpoint data when writing handoffs:
+
+```go
+// In handleSessionEnd, replace the handoff writing section:
+for _, f := range features {
+    activeIDs[f.ID] = true
+    data, err := s.GetHandoffData(f.ID)
+    if err != nil {
+        continue
+    }
+
+    // Load checkpoint data for the active work session's feature
+    var cpData *HandoffCheckpointData
+    if f.ID == ws.FeatureID {
+        obs, _ := s.GetObservationsForWorkSession(ws.ID)
+        mf, _ := s.GetMechanicalFactsForWorkSession(ws.ID)
+        if len(obs) > 0 || mf != nil {
+            cpData = &HandoffCheckpointData{
+                Observations:    obs,
+                MechanicalFacts: mf,
+            }
+        }
+    }
+
+    if writeErr := writeHandoffFileWithCheckpoints(h.CWD, data, cpData); writeErr != nil {
+        s.MarkHandoffStale(ws.ID)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./cmd/docket/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/docket/handoff.go cmd/docket/hook.go
+git commit -m "feat: add Last Session section to handoff from checkpoint observations"
+```
+
+---
+
+### Task 12: Update hooks.json
+
+**Files:**
+- Modify: `plugin/hooks/hooks.json`
+
+- [ ] **Step 1: Update hooks configuration**
+
+Replace `plugin/hooks/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugin/hooks/hooks.json
+git commit -m "feat: add PreCompact and SessionEnd hooks, bump Stop timeout to 30s"
+```
+
+---
+
+### Task 13: Plugin Skills — /checkpoint and /end-session
+
+**Files:**
+- Create: `plugin/skills/checkpoint/SKILL.md`
+- Create: `plugin/skills/end-session/SKILL.md`
+
+- [ ] **Step 1: Create /checkpoint skill**
+
+Create `plugin/skills/checkpoint/SKILL.md`:
+
+```markdown
+---
+name: checkpoint
+description: Force a checkpoint of the current session's context. Preserves what was discussed, decisions made, and work done since the last checkpoint. Use when you want to save progress without ending the session.
+---
+
+# checkpoint: Save Session Context
+
+Force a semantic checkpoint of the current Docket work session.
+
+## Steps
+
+1. **Call the checkpoint MCP tool:**
+   Call `mcp__plugin_docket_docket__checkpoint` with no parameters.
+
+2. **Report the result** to the user — how many chars of semantic text and files were captured.
+
+## Notes
+
+- Checkpoints are processed in the background by the Docket summarizer worker.
+- If no API key is configured, only mechanical facts (files, tests, commits) are captured.
+- The checkpoint is bound to the currently active work session and feature.
+- If no work session is active, the tool will return an error.
+```
+
+- [ ] **Step 2: Create /end-session skill**
+
+Create `plugin/skills/end-session/SKILL.md`:
+
+```markdown
+---
+name: end-session
+description: End the current Docket work session without closing Claude. Forces a final checkpoint, writes the handoff file, and closes the work session. Use when switching features or finishing work but keeping Claude open.
+---
+
+# end-session: End Docket Work Session
+
+End the current Docket work session and write the handoff file.
+
+## Steps
+
+1. **Ask the user** if they want to set a `left_off` note before closing:
+   > "Want to set a 'left off' note for the next session? (optional)"
+
+2. **If they provide a note**, call `mcp__plugin_docket_docket__update_feature` with `left_off`.
+
+3. **Close the work session with a final checkpoint:**
+   Call `mcp__plugin_docket_docket__checkpoint` with `end_session=true`.
+   This forces a checkpoint, writes the handoff file, and closes the work session in one call.
+
+4. **Report** that the work session has been closed and the handoff file has been written.
+
+## Notes
+
+- This does NOT close Claude — only the Docket work session.
+- The handoff file will be available at `.docket/handoff/<feature-id>.md`.
+- Starting work on a new feature after this will open a new work session.
+- This is a user-initiated action — Claude should not call this autonomously.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugin/skills/checkpoint/SKILL.md plugin/skills/end-session/SKILL.md
+git commit -m "feat: add /checkpoint and /end-session plugin skills"
+```
+
+---
+
+### Task 14: Update CLAUDE.md and Documentation
+
+**Files:**
+- Modify: `cmd/docket/update.go` — update the CLAUDE.md snippet
+- Modify: `docs/docket-hooks.md` — update hook documentation
+
+- [ ] **Step 1: Read update.go to understand the snippet**
+
+Read `cmd/docket/update.go` to find the CLAUDE.md snippet template.
+
+- [ ] **Step 2: Update the CLAUDE.md snippet**
+
+Update the snippet in `update.go` to:
+- Remove references to `log_session`
+- Add `/checkpoint` and `/end-session` commands
+- Update the Stop hook description
+- Mention that session context is captured automatically
+
+- [ ] **Step 3: Update docs/docket-hooks.md**
+
+Rewrite `docs/docket-hooks.md` to reflect:
+- Single-phase Stop (no blocking)
+- PreCompact checkpoint preservation
+- SessionEnd cheap finalization
+- Background summarizer worker
+- Removed: two-phase stop, log_session prompting
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./...`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/docket/update.go docs/docket-hooks.md
+git commit -m "docs: update CLAUDE.md snippet and hooks documentation for checkpoint-based flow"
+```
+
+---
+
+### Task 15: Write Feature Documentation
+
+**Files:**
+- Create: `docs/transcript-session-context.md`
+
+- [ ] **Step 1: Write the feature doc**
+
+Create `docs/transcript-session-context.md` following the grug-brain style covering: what it does, why it exists, how to use it, gotchas, and key files.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/transcript-session-context.md
+git commit -m "docs: add transcript-based session context feature documentation"
+```
+
+---
+
+### Task 16: Full Integration Test
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `go test ./... -v`
+Expected: PASS — all packages
+
+- [ ] **Step 2: Build the binary**
+
+Run: `go build -ldflags="-s -w" -o docket.exe ./cmd/docket/`
+Expected: Build succeeds
+
+- [ ] **Step 3: Manual smoke test**
+
+Run: `./docket.exe version`
+Expected: `docket v0.1.0`
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+Only if previous steps revealed issues that needed fixing.

--- a/docs/superpowers/specs/2026-03-29-pretooluse-agent-nudge-design.md
+++ b/docs/superpowers/specs/2026-03-29-pretooluse-agent-nudge-design.md
@@ -1,0 +1,121 @@
+# PreToolUse Agent Nudge — Design Spec
+
+## Problem
+
+When superpowers' plan execution skills (executing-plans, subagent-driven-development) dispatch subagents, they follow their own prescriptive workflow (TodoWrite-based tracking) and ignore the CLAUDE.md docket instructions. This results in:
+
+1. Docket feature cards never getting task items added from the plan
+2. No `get_ready` call before work starts
+3. Session ends with docket having no record of what was planned or completed
+
+The CLAUDE.md snippet already says "Start of work... call get_ready" but this loses to superpowers' skill instructions which are more prescriptive.
+
+## Solution
+
+A PreToolUse hook on the `Agent` tool that checks docket state before subagent dispatch. Nudges once if tracking isn't set up, then stays silent. Combined with a conditional CLAUDE.md snippet paragraph for superpowers users.
+
+## Design
+
+### 1. PreToolUse Hook (hook.go)
+
+**New handler: `handlePreToolUse`**
+
+Fires when `tool_name == "Agent"`. Logic:
+
+1. Check `.docket/` exists — silent pass-through if not a docket project
+2. Check sentinel file `.docket/agent-nudged` — silent pass-through if already nudged this session
+3. Open store, call `ListFeatures("in_progress")`
+4. Branch:
+   - **No in_progress features** — write sentinel, return systemMessage: `[docket] No active docket feature. Call get_ready to set up tracking before dispatching subagents.`
+   - **Feature exists, check task items** — call `GetSubtasksForFeature(feature.ID, false)`, count total items across all subtasks
+     - **Zero task items** — write sentinel, return systemMessage: `[docket] Active feature "<title>" (id: <id>) has no task items. Add task items from the plan before dispatching subagents.`
+     - **Has task items** — silent pass-through (no sentinel write needed, feature is properly set up)
+
+**Output struct** (new, PreToolUse-specific):
+
+```go
+type preToolUseOutput struct {
+    HookSpecificOutput *preToolUseDecision `json:"hookSpecificOutput,omitempty"`
+    SystemMessage      string              `json:"systemMessage,omitempty"`
+}
+
+type preToolUseDecision struct {
+    PermissionDecision string `json:"permissionDecision"`
+}
+```
+
+Always returns `permissionDecision: "allow"` — never blocks the dispatch. The nudge is informational only.
+
+**Sentinel file:** `.docket/agent-nudged`
+- Written on first nudge (empty file, just needs to exist)
+- Checked before nudging — if exists, skip entirely
+- Cleared in `handleSessionStart` alongside `commits.log`
+
+### 2. hooks.json Update
+
+Add PreToolUse matcher:
+
+```json
+"PreToolUse": [
+  {
+    "matcher": "Agent",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "DOCKET_EXE_PATH hook",
+        "timeout": 5
+      }
+    ]
+  }
+]
+```
+
+Same pattern as existing entries — binary path placeholder replaced by install.sh.
+
+### 3. SessionStart Cleanup (hook.go)
+
+In `handleSessionStart`, add after the `commits.log` clear:
+
+```go
+// Clear agent-nudged sentinel
+os.Remove(filepath.Join(h.CWD, ".docket", "agent-nudged"))
+```
+
+### 4. Conditional Snippet in update.go
+
+**Superpowers detection:** Check if `~/.claude/plugins/installed_plugins.json` contains `"superpowers"`. Use `os.UserHomeDir()` + read + string contains check. Simple and reliable.
+
+**When superpowers is detected**, append this paragraph to `docketSection` before the "After a commit" section:
+
+```
+**Plan execution (superpowers):** When using executing-plans or subagent-driven-development,
+set up docket BEFORE dispatching the first task — call `get_ready`, create/find a feature card,
+and use `add_task_item` for each plan task. A PreToolUse hook will remind you if you forget.
+```
+
+**When superpowers is NOT detected**, omit the paragraph. Keeps the snippet clean for non-superpowers users.
+
+**Implementation:** Split `docketSection` into `docketSectionBase` + `docketSectionSuperpowers` + `docketSectionTail`. The `runUpdate` function assembles them based on detection.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `cmd/docket/hook.go` | Add `handlePreToolUse`, new output structs, sentinel write/check, clear sentinel in SessionStart |
+| `plugin/hooks/hooks.json` | Add PreToolUse matcher for Agent |
+| `cmd/docket/update.go` | Split snippet const, superpowers detection, conditional assembly |
+
+## Edge Cases
+
+- **No `.docket/` directory** — hook returns silent pass-through. Same as all other hooks.
+- **quick_track features** — These have no subtasks by design, but quick_track workflows don't dispatch Agent, so the nudge won't fire.
+- **User intentionally skips docket** — Sentinel prevents repeated nagging. One nudge per session, then silent.
+- **Multiple in_progress features** — Check the first (most recent). Same pattern as Stop hook.
+- **Plan auto-imported but no manual task items** — Auto-imported plans create subtasks/items via `ImportPlan`. If the plan was committed and auto-imported before Agent dispatch, the hook will see the items and stay silent. This is the happy path.
+- **Subagent dispatches from within subagents** — PreToolUse fires for each Agent call in the main session. Subagent Agent calls don't trigger plugin hooks (they run in isolated context).
+
+## Testing
+
+- Store tests: existing `GetSubtasksForFeature` coverage is sufficient
+- Hook tests: test `handlePreToolUse` with mock hookInput, verify output for each branch (no features, features without items, features with items, sentinel exists)
+- Integration: manual test with superpowers executing-plans — verify nudge fires before first Agent dispatch, doesn't fire after task items added

--- a/docs/superpowers/specs/2026-03-30-transcript-session-context-design.md
+++ b/docs/superpowers/specs/2026-03-30-transcript-session-context-design.md
@@ -1,0 +1,354 @@
+# Transcript-Based Session Context
+
+Replace Docket's two-phase Stop flow with checkpoint-based context preservation that separates Claude runtime lifecycle from Docket work-session lifecycle.
+
+## Problem
+
+Docket currently blocks Claude at Stop and asks it to call `log_session` with a self-written summary. This has three problems:
+
+1. **Reliability** — Claude sometimes skips `log_session` or writes thin summaries.
+2. **Speed** — the two-phase stop blocks exit and forces an extra round-trip.
+3. **Richness** — valuable context from the conversation (reasoning, dead ends, discoveries) is thrown away. The self-summary captures a fraction of what was actually discussed.
+
+The transcript file contains everything, but mechanical extraction alone is insufficient. Files-edited and tests-run data is reconstructible from git; the real value is the semantic context — what worked, what didn't, what was learned. Extracting that requires an LLM.
+
+## Terminology
+
+**Claude session** — a runtime session managed by Claude Code hooks. Begins at SessionStart, ends at SessionEnd.
+
+**Docket work session** — a Docket-defined span of work on a specific feature. May continue across many Claude turns. Ends when Claude exits or the user explicitly closes it.
+
+**Checkpoint** — a persisted snapshot of meaningful semantic progress plus structured mechanical facts collected since the previous checkpoint.
+
+**Handoff** — a rendered markdown summary for the next fresh Claude session, used to cold-start with status, progress, context, and next steps.
+
+## Design Principles
+
+- Stop means "Claude finished the current reply," not "session ended."
+- PreCompact is the "protect semantic state before compression" event. Claude re-reads CLAUDE.md after compaction but conversation-only context is lost.
+- SessionEnd is for final flush and cleanup, not heavy summarization. It cannot block termination and has a 1.5s default timeout.
+- Docket supports user-declared boundaries (`/end-session`) separate from Claude exit.
+- Hooks never call the model directly. They extract, enqueue, and return.
+- A long-lived Docket worker (in the existing MCP server process) drains checkpoint jobs.
+
+## Architecture
+
+### Components
+
+1. **Transcript filter** (`internal/transcript`) — reads JSONL transcript from a byte offset, strips tool results/inputs/system messages/thinking blocks, keeps assistant and user text blocks. Returns filtered text, new offset, and mechanical facts (files edited, tests run, errors). Knows nothing about docket or features.
+
+2. **Checkpoint job queue** — `checkpoint_jobs` table in SQLite. Hooks insert rows, the background worker drains them.
+
+3. **Background summarizer worker** — runs inside the existing long-lived Docket MCP server process. Polls `checkpoint_jobs`, calls the Anthropic Messages API with filtered transcript delta, writes results to `checkpoint_observations`.
+
+4. **Revised hook handlers** — SessionStart opens work sessions, Stop/PreCompact enqueue checkpoints, SessionEnd does cheap finalization and handoff rendering.
+
+5. **Handoff renderer** — assembles handoff markdown from DB state (feature status, checkpoints, mechanical facts, enrichment sections).
+
+### Data Flow
+
+```
+Claude turn ends
+       |
+    Stop hook fires
+       |
+    Read transcript delta (from last offset)
+    Extract mechanical facts
+    Filter to user/assistant text
+       |
+    Delta meaningful? ----no----> allow stop, done
+       |yes
+    Insert checkpoint_job row
+    Allow stop immediately
+       |
+    [Background worker picks up job]
+       |
+    Call Anthropic Messages API (haiku-tier)
+    with filtered transcript delta
+       |
+    Write checkpoint_observations
+    Update transcript offset
+```
+
+## State Machine
+
+### States
+
+| State | Meaning |
+|-------|---------|
+| NoActiveWorkSession | No feature bound to an open work session |
+| ActiveClean | Work session open, no meaningful uncheckpointed delta |
+| ActiveDirty | Work session open, new state not yet checkpointed |
+| CheckpointQueued | Checkpoint job enqueued or running |
+| Closing | Finalizing work session, writing handoff |
+
+### Transitions
+
+| From | To | Trigger |
+|------|----|---------|
+| NoActiveWorkSession | ActiveClean | SessionStart opens/resumes work session |
+| ActiveClean | ActiveDirty | New meaningful transcript delta, file edits, commits, failures |
+| ActiveDirty | CheckpointQueued | Stop, PreCompact, `/checkpoint`, `/end-session` |
+| CheckpointQueued | ActiveClean | Checkpoint completes, no newer delta |
+| CheckpointQueued | ActiveDirty | Checkpoint completes, newer dirty state arrived |
+| ActiveClean | Closing | `/end-session` or SessionEnd |
+| ActiveDirty | Closing | `/end-session` or SessionEnd (forces final cheap flush) |
+| Closing | NoActiveWorkSession | Handoff written, work session closed |
+
+## Hook Responsibilities
+
+### SessionStart
+
+Resolve active feature. Open or resume a Docket work session. Load latest handoff and recent durable context for injection. Transition to ActiveClean.
+
+Does not create a checkpoint or write a handoff.
+
+### Stop
+
+Read transcript delta from last cursor. Extract semantic delta (user/assistant text only). Merge structured mechanical facts collected since last checkpoint.
+
+If delta is trivial: leave state unchanged, allow stop.
+If delta is meaningful: insert `checkpoint_jobs` row, transition to CheckpointQueued, allow stop immediately.
+
+Does not block Claude. Does not close the work session. Does not write handoff.
+
+### PreCompact
+
+Force checkpoint enqueue even if the normal threshold is not met. Uses the same summarizer pipeline as Stop — no special-case code. The checkpoint job includes transcript delta, trigger type (manual/auto), and structured facts since last checkpoint.
+
+Does not close the work session. Does not write handoff.
+
+PostCompact is deferred to v1.1+ (optional observer storing `compact_summary` as a non-canonical debugging observation).
+
+### SessionEnd
+
+Final cheap flush of already-collected mechanical state. Render handoff from completed checkpoints and structured facts. Mark work session closed. Transition through Closing to NoActiveWorkSession.
+
+Does not wait for in-flight semantic checkpoint jobs. Does not perform LLM calls.
+
+If an in-flight job finishes after SessionEnd, it writes to `checkpoint_observations` only. It must not reopen the closed work session. The next handoff rewrite or next session can consume that late observation.
+
+## Meaningful Delta Threshold
+
+A checkpoint is required if any of these are true:
+
+- Filtered semantic text since last checkpoint >= 300 chars
+- At least 1 non-trivial user message in the delta
+- Any commit occurred
+- Any test failure or tool failure occurred
+- Any explicit `/checkpoint` or `/end-session`
+- Any PreCompact trigger
+
+A delta is trivial if all are true:
+
+- Filtered semantic text < 300 chars
+- No commit
+- No failure
+- No explicit checkpoint/end-session
+- No PreCompact
+
+"Non-trivial user message" in v1: not empty, not only acknowledgment/control text (ok, thanks, continue, go on, run it, yep). Deterministic filter, tunable later.
+
+## Docket Commands
+
+### /checkpoint
+
+Both a plugin skill and an MCP tool. Forces transcript delta extraction and enqueues a checkpoint if anything meaningful exists. Keeps the work session open.
+
+Safe for both manual and programmatic use.
+
+### /end-session
+
+Plugin skill only in v1. Not exposed as an MCP tool — Claude must not autonomously close a work session.
+
+Forces a final checkpoint if needed. Renders and writes handoff. Closes the work session. Transitions to NoActiveWorkSession.
+
+Exists because Claude's SessionEnd only covers real session termination, not user-declared work boundaries inside a still-open CLI session.
+
+## Feature Binding
+
+Checkpoints bind to the active Docket work session at enqueue time. The work session's `feature_id` is the source of truth.
+
+- If no active work session exists, skip semantic checkpointing and log a debug event.
+- If multiple features are in_progress but no work session is open, only SessionStart may pick a fallback. Normal hooks must not guess.
+- Feature status (`in_progress`, `done`, etc.) answers "is this work ongoing overall?"
+- Work session status (`open`, `closed`) answers "is there an active Docket session bound right now?"
+
+A feature may remain `in_progress` after its work session closes.
+
+## Checkpoint Model
+
+### What a checkpoint contains
+
+**Semantic state** (from LLM summarization of filtered transcript delta):
+- Clarified goals
+- Decisions discussed
+- Blockers discovered
+- Dead ends and what didn't work
+- Next-step intent
+
+**Mechanical state** (deterministic extraction):
+- Files edited (path + action + count)
+- Tests and commands run
+- Commit hashes and messages
+- Failures and error summaries
+
+### Checkpoint identity
+
+Each checkpoint is idempotent. Key: `session_id + transcript_start_offset + transcript_end_offset + feature_id`. Prevents duplicate observations if hooks retrigger or the process retries.
+
+## Handoff Generation
+
+### Inputs
+
+- Current feature status and progress
+- Left-off state
+- Next tasks
+- Deduplicated key files (auto-merged from checkpoint file edits)
+- Recent checkpoint observations
+- Open blockers
+- Recent commits/tests/errors
+- Preserved enrichment sections (Decisions & Context, Gotchas, Recommended Approach)
+
+### Write points
+
+**Write now:** `/end-session`, SessionEnd.
+
+**Do not write:** normal Stop, PreCompact.
+
+### Sections
+
+- Status
+- Current objective (from most recent checkpoint semantic state)
+- Last Session (accumulated checkpoint observations + mechanical facts)
+- Next Tasks
+- Key Files
+- Blockers / Gotchas
+- Recent commits/tests/errors
+
+## Summarizer Configuration
+
+Reuse `ANTHROPIC_API_KEY` — no separate `DOCKET_API_KEY`.
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `ANTHROPIC_API_KEY` | API authentication | required for semantic checkpoints |
+| `DOCKET_SUMMARIZER_MODEL` | Model for checkpoint summarization | baked-in cheap default (haiku-tier) |
+| `DOCKET_SUMMARIZER_ENABLED` | Toggle | `true` if API key exists |
+
+If no API key exists, Docket falls back to mechanical-only checkpoints. All hook flows still work — checkpoints just lack semantic observations.
+
+### Backend interface
+
+```go
+type SummarizerBackend interface {
+    Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error)
+}
+```
+
+v1 ships with a direct Anthropic Messages API implementation in Go. No Agent SDK dependency.
+
+## Schema Changes
+
+### New tables
+
+**work_sessions**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PRIMARY KEY | |
+| feature_id | TEXT NOT NULL | FK to features |
+| claude_session_id | TEXT | from hook input |
+| status | TEXT | open, closed |
+| started_at | DATETIME | |
+| ended_at | DATETIME | nullable |
+| handoff_stale | BOOLEAN | true if handoff render failed |
+
+**checkpoint_jobs**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PRIMARY KEY | |
+| work_session_id | INTEGER | FK to work_sessions |
+| feature_id | TEXT NOT NULL | copied from work session at enqueue |
+| reason | TEXT | stop, precompact, manual_checkpoint, manual_end_session |
+| trigger | TEXT | auto, manual, null |
+| transcript_start_offset | INTEGER | byte offset |
+| transcript_end_offset | INTEGER | byte offset |
+| status | TEXT | queued, running, done, failed, skipped |
+| error | TEXT | nullable |
+| created_at | DATETIME | |
+| started_at | DATETIME | nullable |
+| finished_at | DATETIME | nullable |
+
+**checkpoint_observations**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | INTEGER PRIMARY KEY | |
+| checkpoint_job_id | INTEGER | FK to checkpoint_jobs |
+| work_session_id | INTEGER | FK to work_sessions |
+| feature_id | TEXT NOT NULL | |
+| kind | TEXT | summary, blocker, decision_candidate, dead_end, next_step, gotcha |
+| payload_json | TEXT | structured data |
+| summary_text | TEXT | human-readable text |
+| created_at | DATETIME | |
+
+### Existing tables
+
+No changes to features, sessions, subtasks, decisions, issues. The existing `sessions` table remains for coarse session history. Checkpoint observations are the fine-grained semantic layer.
+
+## Removals
+
+- `log_session` MCP tool (registration in `tools.go`, handler in `tools_session.go`)
+- Two-phase Stop logic (`stop_hook_active` branching for block/re-trigger)
+- `session-logged` sentinel file (`.docket/session-logged`)
+- `MarkSessionLogged()`, `WasSessionLogged()`, `ClearSessionLogged()` store methods
+- The Stop hook block/reason prompting flow
+
+## What Stays
+
+- `commits.log` — fast append-only buffer for PostToolUse commit detection. Handoff rendering prefers normalized commit facts in DB if they exist. `commits.log` is an ingestion source, not long-term source of truth.
+- `compact_sessions` MCP tool — manages historical session data, unrelated to this change.
+- SessionStart context injection — loads handoff for new sessions.
+- PostToolUse commit tracking — appends to `commits.log`.
+- Enrichment section preservation in handoff files.
+
+## Hooks Configuration Changes
+
+Update `hooks.json`:
+
+- Stop timeout: 15s → 30s (headroom for transcript extraction)
+- Add PreCompact hook (same command, `docket.exe hook`)
+- Add SessionEnd hook (same command, `docket.exe hook`)
+- SessionEnd timeout: raise via config if default 1.5s is insufficient for handoff rendering
+
+## Error Handling
+
+- **Transcript missing/unreadable:** Fall back to `commits.log` data. Log mechanical-only checkpoint. Allow stop.
+- **Malformed JSONL lines:** Skip individual lines, log to stderr, keep parsing.
+- **No active work session:** Skip semantic checkpointing, log debug event.
+- **Summarizer API failure:** Mark checkpoint job as failed. Mechanical facts still stored. Retry on next checkpoint if delta accumulates.
+- **Handoff render failure during /end-session:** Set `handoff_stale=true`, log error, close work session anyway. Next SessionStart or explicit handoff regeneration repairs it.
+- **SessionEnd timeout pressure:** Handoff rendering must be fast (read from DB, template, write file). No LLM calls. If still tight, the timeout can be raised via `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS`.
+
+## Invariants
+
+1. A Stop hook must never be the only path to a durable handoff. Claude may continue for many turns after Stop.
+2. SessionEnd must not depend on a slow model round-trip.
+3. Any important instruction or conclusion that must survive compaction or fresh sessions must exist outside the conversation.
+4. Mechanical facts come from deterministic event capture, not transcript inference.
+5. Semantic checkpoints are idempotent and feature-bound at enqueue time.
+6. Hooks never call the model directly. They enqueue.
+
+## Key Files (post-implementation)
+
+- `internal/transcript/` — JSONL parser, delta filter, mechanical fact extractor
+- `internal/checkpoint/` — job queue, worker, summarizer backend interface
+- `internal/checkpoint/anthropic.go` — Messages API summarizer implementation
+- `internal/store/migrate.go` — schema v8 (work_sessions, checkpoint_jobs, checkpoint_observations)
+- `cmd/docket/hook.go` — revised Stop, new PreCompact, new SessionEnd handlers
+- `cmd/docket/handoff.go` — revised renderer consuming checkpoint observations
+- `plugin/hooks/hooks.json` — updated hook declarations
+- `plugin/skills/checkpoint/SKILL.md` — /checkpoint skill
+- `plugin/skills/end-session/SKILL.md` — /end-session skill

--- a/docs/tags-and-archival.md
+++ b/docs/tags-and-archival.md
@@ -1,0 +1,42 @@
+# Tags and Archival
+
+## What it does
+
+Two additions to feature tracking:
+
+1. **Tags** — free-form string tags on features for categorization. Comma-separated input, stored as JSON array in SQLite. New-tag warnings help catch typos by listing existing tags when you add one that doesn't exist yet.
+
+2. **Archival** — `archived` is a feature status. Done features auto-archive after 7 days (checked on SessionStart). Archived features are hidden from `list_features` and the dashboard by default. No special tool needed — use `update_feature(status="planned")` to unarchive.
+
+## How to use
+
+**Tags:**
+- `add_feature(title="...", tags="auth,frontend")` — set tags on creation
+- `update_feature(id="...", tags="backend,api")` — replace all tags
+- `list_features(tag="auth")` — filter by tag
+
+**Archival:**
+- Features marked `done` for 7+ days auto-archive on next session start
+- `list_features(status="archived")` — see archived features
+- `update_feature(id="...", status="planned")` — unarchive
+- Dashboard has an archive toggle button in the header
+
+## Gotchas
+
+- Tags are exact-match only. No fuzzy matching. The new-tag warning is your typo detector.
+- `tags` param on `update_feature` replaces all tags, not appends. Send the full list.
+- No `list_tags` or `delete_tag` tool. Tags are derived from what features have — unused tags disappear naturally.
+- Auto-archive is hardcoded to 7 days. No config file.
+- Archiving bypasses the completion gate — you can archive features with unchecked items.
+- `get_feature` and `get_context` return any feature regardless of status, including archived.
+
+## Key files
+
+- `internal/store/migrate.go` — schemaV8 (tags column)
+- `internal/store/store.go` — Tags field, GetKnownTags, CheckNewTags, ListFeaturesWithTag, AutoArchiveStale
+- `internal/store/tags_test.go` — tag tests
+- `internal/store/archive_test.go` — archival tests
+- `internal/mcp/tools.go` — tags/tag params on MCP tools
+- `internal/mcp/tools_feature.go` — tag handling in handlers
+- `cmd/docket/hook.go` — auto-archive in SessionStart
+- `dashboard/index.html` — tag pills, archived toggle

--- a/docs/transcript-session-context.md
+++ b/docs/transcript-session-context.md
@@ -1,0 +1,77 @@
+# Transcript-Based Session Context
+
+Docket captures what happened during a Claude Code session — not just commits and files, but reasoning, decisions, dead ends, and gotchas. This context carries over to the next session via handoff files.
+
+## What it does
+
+When Claude works on a feature, docket:
+1. Opens a **work session** linking the Claude session to the active feature
+2. On each Stop hook (fires every turn), checks if anything meaningful happened
+3. If yes, enqueues a **checkpoint job** with the transcript delta
+4. A background worker summarizes the delta using the Anthropic API
+5. At session end, writes a **handoff file** with all accumulated observations
+
+The next session gets the handoff file injected as context at startup.
+
+## How it works
+
+### Transcript parsing
+
+Claude Code stores conversation transcripts as JSONL files. The parser (`internal/transcript/parse.go`) reads from a byte offset, extracts:
+- **Semantic text**: user and assistant messages (no tool results, no file contents)
+- **Mechanical facts**: files edited (with counts), test runs (pass/fail), commits (hash + message), errors
+
+Trivial user messages ("ok", "thanks", "continue") are filtered out when deciding if content is meaningful.
+
+### Checkpoint jobs
+
+Each checkpoint is a row in `checkpoint_jobs` with the semantic text, mechanical facts, and transcript byte offsets. Jobs go through: queued → running → done/failed.
+
+The worker polls every 5 seconds, dequeues one job at a time, calls the summarizer, and writes observations.
+
+### Summarizer
+
+The Anthropic Messages API (haiku-tier by default) extracts structured observations:
+- Summary narrative
+- Blockers, dead ends, decisions, next steps, gotchas
+
+No API key = noop summarizer (only mechanical facts survive).
+
+### Work sessions
+
+A work session ties a Claude session ID to a feature ID. One active at a time. Opened at SessionStart, closed at SessionEnd. Checkpoint observations are grouped by work session.
+
+## How to use it
+
+It's automatic. Just work normally with docket features.
+
+Manual controls:
+- `/checkpoint` — force a checkpoint mid-session
+- `/end-session` — close the work session without closing Claude (useful when switching features)
+
+## Gotchas
+
+- **API key required for summaries**: Set `ANTHROPIC_API_KEY`. Without it, only mechanical facts are captured (files, tests, commits). No semantic summary.
+- **Transcript path**: Claude Code must provide the transcript path in hook input. If missing, transcript parsing is skipped (commits.log still works).
+- **Meaningful delta threshold**: Stop only checkpoints if there are commits, errors, failed tests, 300+ chars of text, or non-trivial user input. This avoids noise from quick yes/no exchanges.
+- **PreCompact always checkpoints**: No threshold — context compression means data loss, so we save everything before it happens.
+- **SessionEnd is cheap**: Just enqueues remaining delta and writes handoffs. No blocking, no model calls.
+- **Worker timeout**: 30 seconds per summarization. Failures are logged, job marked failed, and the worker moves on.
+
+## Key files
+
+- `internal/transcript/types.go` — Delta struct, trivial message map
+- `internal/transcript/parse.go` — JSONL transcript parser
+- `internal/checkpoint/summarizer.go` — SummarizerBackend interface
+- `internal/checkpoint/anthropic.go` — Anthropic Messages API implementation
+- `internal/checkpoint/noop.go` — No-op summarizer (no API key)
+- `internal/checkpoint/config.go` — Config from env vars
+- `internal/checkpoint/worker.go` — Background job queue worker
+- `internal/store/worksession.go` — Work session CRUD
+- `internal/store/checkpoint.go` — Checkpoint job + observation CRUD
+- `internal/store/migrate.go` — Schema v9 (work_sessions, checkpoint_jobs, checkpoint_observations)
+- `cmd/docket/hook.go` — Hook handlers (Stop, PreCompact, SessionEnd, SessionStart)
+- `cmd/docket/handoff.go` — Handoff renderer with Last Session section
+- `plugin/hooks/hooks.json` — Hook declarations
+- `plugin/skills/checkpoint/SKILL.md` — /checkpoint skill
+- `plugin/skills/end-session/SKILL.md` — /end-session skill

--- a/internal/checkpoint/anthropic.go
+++ b/internal/checkpoint/anthropic.go
@@ -1,0 +1,133 @@
+package checkpoint
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const defaultBaseURL = "https://api.anthropic.com"
+const anthropicVersion = "2023-06-01"
+
+// AnthropicSummarizer calls the Anthropic Messages API to summarize transcript deltas.
+type AnthropicSummarizer struct {
+	apiKey  string
+	model   string
+	baseURL string
+	client  *http.Client
+}
+
+// NewAnthropicSummarizer creates a summarizer using the Anthropic Messages API.
+func NewAnthropicSummarizer(cfg Config) *AnthropicSummarizer {
+	return &AnthropicSummarizer{
+		apiKey:  cfg.APIKey,
+		model:   cfg.Model,
+		baseURL: defaultBaseURL,
+		client:  &http.Client{},
+	}
+}
+
+type messagesRequest struct {
+	Model     string       `json:"model"`
+	MaxTokens int          `json:"max_tokens"`
+	System    string       `json:"system"`
+	Messages  []messageReq `json:"messages"`
+}
+
+type messageReq struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type messagesResponse struct {
+	Content []contentResp `json:"content"`
+	Error   *apiError     `json:"error"`
+}
+
+type contentResp struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type apiError struct {
+	Message string `json:"message"`
+}
+
+func (s *AnthropicSummarizer) Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error) {
+	systemPrompt := `You are a session context extractor for a software development feature tracker. Given a conversation excerpt between a developer and an AI assistant, extract structured information about what happened.
+
+Respond with ONLY a JSON object (no markdown, no explanation) with these fields:
+- "summary": 2-4 sentence narrative of what was discussed and accomplished
+- "blockers": array of strings — anything blocking progress
+- "dead_ends": array of strings — approaches tried that didn't work
+- "next_steps": array of strings — what should happen next
+- "decisions": array of strings — decisions made during the conversation
+- "gotchas": array of strings — non-obvious discoveries or warnings
+
+Use empty arrays for fields with no content. Be concise.`
+
+	userContent := fmt.Sprintf("Feature: %s\nCheckpoint reason: %s\n\nConversation excerpt:\n%s",
+		input.FeatureTitle, input.Reason, input.SemanticText)
+
+	// Truncate if too long (keep last part which is most relevant)
+	if len(userContent) > 30000 {
+		userContent = userContent[len(userContent)-30000:]
+	}
+
+	reqBody := messagesRequest{
+		Model:     s.model,
+		MaxTokens: 1024,
+		System:    systemPrompt,
+		Messages: []messageReq{
+			{Role: "user", Content: userContent},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", s.baseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", s.apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("api call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("api error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var msgResp messagesResponse
+	if err := json.Unmarshal(respBody, &msgResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	if len(msgResp.Content) == 0 {
+		return nil, fmt.Errorf("empty response content")
+	}
+
+	var output SummarizeOutput
+	if err := json.Unmarshal([]byte(msgResp.Content[0].Text), &output); err != nil {
+		// If JSON parsing fails, use raw text as summary
+		output.Summary = msgResp.Content[0].Text
+	}
+
+	return &output, nil
+}

--- a/internal/checkpoint/anthropic_test.go
+++ b/internal/checkpoint/anthropic_test.go
@@ -1,0 +1,81 @@
+package checkpoint
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAnthropicSummarizer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") != "test-key" {
+			t.Errorf("missing api key header")
+		}
+		if r.Header.Get("anthropic-version") == "" {
+			t.Errorf("missing anthropic-version header")
+		}
+
+		resp := map[string]any{
+			"content": []map[string]any{
+				{
+					"type": "text",
+					"text": `{"summary":"Discussed auth token refresh design. Decided on rotating tokens.","blockers":[],"dead_ends":["Tried stateless refresh but abandoned due to revocation complexity"],"next_steps":["Implement token rotation endpoint"],"decisions":["Use rotating refresh tokens"],"gotchas":["Token expiry must be checked server-side"]}`,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	s := &AnthropicSummarizer{
+		apiKey:  "test-key",
+		model:   "claude-haiku-4-5-20251001",
+		baseURL: srv.URL,
+		client:  &http.Client{},
+	}
+
+	out, err := s.Summarize(context.Background(), SummarizeInput{
+		SemanticText: "User: How should we handle token refresh?\nAssistant: I recommend rotating refresh tokens...",
+		FeatureTitle: "Auth System",
+		Reason:       "stop",
+	})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if out.Summary == "" {
+		t.Error("expected non-empty summary")
+	}
+	if len(out.DeadEnds) != 1 {
+		t.Errorf("DeadEnds = %d, want 1", len(out.DeadEnds))
+	}
+	if len(out.Decisions) != 1 {
+		t.Errorf("Decisions = %d, want 1", len(out.Decisions))
+	}
+}
+
+func TestAnthropicSummarizerAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`{"error":{"message":"internal error"}}`))
+	}))
+	defer srv.Close()
+
+	s := &AnthropicSummarizer{
+		apiKey:  "test-key",
+		model:   "claude-haiku-4-5-20251001",
+		baseURL: srv.URL,
+		client:  &http.Client{},
+	}
+
+	_, err := s.Summarize(context.Background(), SummarizeInput{
+		SemanticText: "some text",
+		FeatureTitle: "Test",
+		Reason:       "stop",
+	})
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}

--- a/internal/checkpoint/config.go
+++ b/internal/checkpoint/config.go
@@ -1,0 +1,32 @@
+package checkpoint
+
+import "os"
+
+const defaultModel = "claude-haiku-4-5-20251001"
+
+// Config holds summarizer configuration from environment variables.
+type Config struct {
+	APIKey  string
+	Model   string
+	Enabled bool
+}
+
+// LoadConfig reads summarizer configuration from environment variables.
+func LoadConfig() Config {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	model := os.Getenv("DOCKET_SUMMARIZER_MODEL")
+	if model == "" {
+		model = defaultModel
+	}
+
+	enabled := apiKey != ""
+	if v := os.Getenv("DOCKET_SUMMARIZER_ENABLED"); v == "false" {
+		enabled = false
+	}
+
+	return Config{
+		APIKey:  apiKey,
+		Model:   model,
+		Enabled: enabled,
+	}
+}

--- a/internal/checkpoint/noop.go
+++ b/internal/checkpoint/noop.go
@@ -1,0 +1,10 @@
+package checkpoint
+
+import "context"
+
+// NoopSummarizer returns empty output. Used when no API key is configured.
+type NoopSummarizer struct{}
+
+func (n *NoopSummarizer) Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error) {
+	return &SummarizeOutput{}, nil
+}

--- a/internal/checkpoint/summarizer.go
+++ b/internal/checkpoint/summarizer.go
@@ -1,0 +1,25 @@
+package checkpoint
+
+import "context"
+
+// SummarizeInput is what the worker sends to the summarizer.
+type SummarizeInput struct {
+	SemanticText string // filtered user/assistant transcript delta
+	FeatureTitle string // for context
+	Reason       string // stop, precompact, manual_checkpoint, manual_end_session
+}
+
+// SummarizeOutput is what the summarizer returns.
+type SummarizeOutput struct {
+	Summary   string   `json:"summary"`   // human-readable narrative
+	Blockers  []string `json:"blockers"`  // discovered blockers
+	DeadEnds  []string `json:"dead_ends"` // things tried that didn't work
+	NextSteps []string `json:"next_steps"` // intent for next session
+	Decisions []string `json:"decisions"` // decisions discussed
+	Gotchas   []string `json:"gotchas"`   // non-obvious discoveries
+}
+
+// SummarizerBackend processes transcript deltas into structured observations.
+type SummarizerBackend interface {
+	Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error)
+}

--- a/internal/checkpoint/worker.go
+++ b/internal/checkpoint/worker.go
@@ -1,0 +1,158 @@
+package checkpoint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sniffle6/claude-docket/internal/store"
+)
+
+// Worker drains checkpoint_jobs and calls the summarizer for each.
+type Worker struct {
+	store      *store.Store
+	summarizer SummarizerBackend
+}
+
+func NewWorker(s *store.Store, summarizer SummarizerBackend) *Worker {
+	return &Worker{store: s, summarizer: summarizer}
+}
+
+// Run polls for queued jobs and processes them until ctx is cancelled.
+func (w *Worker) Run(ctx context.Context, pollInterval time.Duration) {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for w.ProcessOne() {
+				// drain all queued jobs before waiting
+			}
+		}
+	}
+}
+
+// ProcessOne dequeues and processes a single checkpoint job.
+// Returns true if a job was processed, false if the queue was empty.
+func (w *Worker) ProcessOne() bool {
+	job, err := w.store.DequeueCheckpointJob()
+	if err != nil || job == nil {
+		return false
+	}
+
+	// Get feature title for context
+	featureTitle := job.FeatureID
+	if f, err := w.store.GetFeature(job.FeatureID); err == nil {
+		featureTitle = f.Title
+	}
+
+	// If semantic text is empty, skip LLM call but still mark done
+	if job.SemanticText == "" {
+		w.store.CompleteCheckpointJob(job.ID, nil)
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	output, err := w.summarizer.Summarize(ctx, SummarizeInput{
+		SemanticText: job.SemanticText,
+		FeatureTitle: featureTitle,
+		Reason:       job.Reason,
+	})
+	if err != nil {
+		errMsg := err.Error()
+		w.store.FailCheckpointJob(job.ID, errMsg)
+		fmt.Fprintf(os.Stderr, "docket checkpoint worker: summarize job %d: %v\n", job.ID, err)
+		return true
+	}
+
+	// Write observations
+	w.writeObservations(job, output)
+	w.store.CompleteCheckpointJob(job.ID, nil)
+
+	// Auto-merge key_files from mechanical facts
+	w.mergeKeyFiles(job)
+
+	return true
+}
+
+func (w *Worker) writeObservations(job *store.CheckpointJob, output *SummarizeOutput) {
+	if output.Summary != "" {
+		payload, _ := json.Marshal(output)
+		w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+			CheckpointJobID: job.ID,
+			WorkSessionID:   job.WorkSessionID,
+			FeatureID:       job.FeatureID,
+			Kind:            "summary",
+			PayloadJSON:     string(payload),
+			SummaryText:     output.Summary,
+		})
+	}
+	for _, b := range output.Blockers {
+		w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+			CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+			FeatureID: job.FeatureID, Kind: "blocker", SummaryText: b,
+		})
+	}
+	for _, d := range output.DeadEnds {
+		w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+			CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+			FeatureID: job.FeatureID, Kind: "dead_end", SummaryText: d,
+		})
+	}
+	for _, n := range output.NextSteps {
+		w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+			CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+			FeatureID: job.FeatureID, Kind: "next_step", SummaryText: n,
+		})
+	}
+	for _, d := range output.Decisions {
+		w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+			CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+			FeatureID: job.FeatureID, Kind: "decision_candidate", SummaryText: d,
+		})
+	}
+	for _, g := range output.Gotchas {
+		w.store.AddCheckpointObservation(store.CheckpointObservationInput{
+			CheckpointJobID: job.ID, WorkSessionID: job.WorkSessionID,
+			FeatureID: job.FeatureID, Kind: "gotcha", SummaryText: g,
+		})
+	}
+}
+
+func (w *Worker) mergeKeyFiles(job *store.CheckpointJob) {
+	var facts store.MechanicalFacts
+	if err := json.Unmarshal([]byte(job.MechanicalJSON), &facts); err != nil || len(facts.FilesEdited) == 0 {
+		return
+	}
+
+	feature, err := w.store.GetFeature(job.FeatureID)
+	if err != nil {
+		return
+	}
+
+	existing := make(map[string]bool, len(feature.KeyFiles))
+	for _, f := range feature.KeyFiles {
+		existing[f] = true
+	}
+
+	merged := append([]string{}, feature.KeyFiles...)
+	changed := false
+	for _, fe := range facts.FilesEdited {
+		if !existing[fe.Path] {
+			merged = append(merged, fe.Path)
+			existing[fe.Path] = true
+			changed = true
+		}
+	}
+
+	if changed {
+		w.store.UpdateFeature(job.FeatureID, store.FeatureUpdate{KeyFiles: &merged})
+	}
+}

--- a/internal/checkpoint/worker_test.go
+++ b/internal/checkpoint/worker_test.go
@@ -1,0 +1,120 @@
+package checkpoint
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sniffle6/claude-docket/internal/store"
+)
+
+type mockSummarizer struct {
+	calls  int
+	output *SummarizeOutput
+	err    error
+}
+
+func (m *mockSummarizer) Summarize(ctx context.Context, input SummarizeInput) (*SummarizeOutput, error) {
+	m.calls++
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.output != nil {
+		return m.output, nil
+	}
+	return &SummarizeOutput{
+		Summary:  "Test summary",
+		Blockers: []string{},
+	}, nil
+}
+
+func TestWorkerProcessesJob(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	s.EnqueueCheckpointJob(store.CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   512,
+		SemanticText:          "discussed auth design",
+		MechanicalFacts:       store.MechanicalFacts{},
+	})
+
+	mock := &mockSummarizer{}
+	w := NewWorker(s, mock)
+
+	processed := w.ProcessOne()
+	if !processed {
+		t.Fatal("expected to process a job")
+	}
+	if mock.calls != 1 {
+		t.Errorf("summarizer calls = %d, want 1", mock.calls)
+	}
+
+	obs, _ := s.GetObservationsForWorkSession(ws.ID)
+	if len(obs) == 0 {
+		t.Fatal("expected at least one observation")
+	}
+	if obs[0].Kind != "summary" {
+		t.Errorf("Kind = %q, want %q", obs[0].Kind, "summary")
+	}
+}
+
+func TestWorkerSkipsNoopOnEmptyText(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	s.EnqueueCheckpointJob(store.CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   512,
+		SemanticText:          "", // empty
+		MechanicalFacts:       store.MechanicalFacts{FilesEdited: []store.FileEdit{{Path: "a.go", Count: 1}}},
+	})
+
+	mock := &mockSummarizer{}
+	w := NewWorker(s, mock)
+	w.ProcessOne()
+
+	if mock.calls != 0 {
+		t.Errorf("expected 0 summarizer calls for empty text, got %d", mock.calls)
+	}
+
+	job, _ := s.GetCheckpointJob(1)
+	if job.Status != "done" {
+		t.Errorf("Status = %q, want done (skipped)", job.Status)
+	}
+}
+
+func TestWorkerRunLoop(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	mock := &mockSummarizer{}
+	w := NewWorker(s, mock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	w.Run(ctx, 50*time.Millisecond)
+	// No panic = pass
+}

--- a/internal/handoff/render.go
+++ b/internal/handoff/render.go
@@ -1,0 +1,210 @@
+package handoff
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sniffle6/claude-docket/internal/store"
+)
+
+// CheckpointData holds checkpoint observations and mechanical facts for
+// inclusion in a handoff file's "Last Session" section.
+type CheckpointData struct {
+	Observations    []store.CheckpointObservation
+	MechanicalFacts *store.MechanicalFacts
+}
+
+// Render produces the markdown text for a handoff file.
+func Render(data *store.HandoffData, cpData *CheckpointData) string {
+	var b strings.Builder
+	f := data.Feature
+
+	fmt.Fprintf(&b, "# Handoff: %s\n\n", f.Title)
+
+	fmt.Fprintf(&b, "## Status\n")
+	fmt.Fprintf(&b, "%s | Progress: %d/%d | Updated: %s\n\n",
+		f.Status, data.Done, data.Total, f.UpdatedAt.Format("2006-01-02 15:04"))
+
+	if f.LeftOff != "" {
+		fmt.Fprintf(&b, "## Left Off\n%s\n\n", f.LeftOff)
+	}
+
+	// Last Session section from checkpoint observations
+	if cpData != nil && (len(cpData.Observations) > 0 || cpData.MechanicalFacts != nil) {
+		b.WriteString("## Last Session\n")
+
+		for _, obs := range cpData.Observations {
+			switch obs.Kind {
+			case "summary":
+				fmt.Fprintf(&b, "%s\n\n", obs.SummaryText)
+			case "blocker":
+				fmt.Fprintf(&b, "- **Blocker:** %s\n", obs.SummaryText)
+			case "dead_end":
+				fmt.Fprintf(&b, "- **Dead end:** %s\n", obs.SummaryText)
+			case "next_step":
+				fmt.Fprintf(&b, "- **Next:** %s\n", obs.SummaryText)
+			case "decision_candidate":
+				fmt.Fprintf(&b, "- **Decision:** %s\n", obs.SummaryText)
+			case "gotcha":
+				fmt.Fprintf(&b, "- **Gotcha:** %s\n", obs.SummaryText)
+			}
+		}
+
+		if cpData.MechanicalFacts != nil {
+			mf := cpData.MechanicalFacts
+			if len(mf.FilesEdited) > 0 {
+				var parts []string
+				for _, fe := range mf.FilesEdited {
+					if fe.Count > 1 {
+						parts = append(parts, fmt.Sprintf("%s (%d×)", fe.Path, fe.Count))
+					} else {
+						parts = append(parts, fe.Path)
+					}
+				}
+				fmt.Fprintf(&b, "\nFiles: %s\n", strings.Join(parts, ", "))
+			}
+			if len(mf.TestRuns) > 0 {
+				passed := 0
+				for _, tr := range mf.TestRuns {
+					if tr.Passed {
+						passed++
+					}
+				}
+				fmt.Fprintf(&b, "Tests: %d runs (%d passed, %d failed)\n",
+					len(mf.TestRuns), passed, len(mf.TestRuns)-passed)
+			}
+			if len(mf.Commits) > 0 {
+				var msgs []string
+				for _, c := range mf.Commits {
+					msgs = append(msgs, fmt.Sprintf("%q", c.Message))
+				}
+				fmt.Fprintf(&b, "Commits: %s\n", strings.Join(msgs, ", "))
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	if len(data.NextTasks) > 0 {
+		b.WriteString("## Next Tasks\n")
+		for _, task := range data.NextTasks {
+			fmt.Fprintf(&b, "- [ ] %s\n", task)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(f.KeyFiles) > 0 {
+		b.WriteString("## Key Files\n")
+		for _, kf := range f.KeyFiles {
+			fmt.Fprintf(&b, "- %s\n", kf)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(data.RecentSessions) > 0 {
+		b.WriteString("## Recent Activity\n")
+		for _, sess := range data.RecentSessions {
+			line := fmt.Sprintf("- %s: %s", sess.CreatedAt.Format("2006-01-02"), sess.Summary)
+			if len(sess.Commits) > 0 {
+				line += fmt.Sprintf(" [%s]", strings.Join(sess.Commits, ", "))
+			}
+			fmt.Fprintf(&b, "%s\n", line)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(data.SubtaskSummary) > 0 {
+		b.WriteString("## Active Subtasks\n")
+		for _, st := range data.SubtaskSummary {
+			fmt.Fprintf(&b, "- %s [%d/%d]\n", st.Title, st.Done, st.Total)
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// enrichmentHeadings are sections written by board-manager that should be
+// preserved when the Stop hook rewrites the mechanical baseline.
+var enrichmentHeadings = []string{
+	"## Decisions & Context",
+	"## Gotchas",
+	"## Recommended Approach",
+}
+
+// WriteFile writes a handoff markdown file to .docket/handoff/<featureID>.md,
+// preserving any enrichment sections from a previous version of the file.
+func WriteFile(dir string, data *store.HandoffData, cpData *CheckpointData) error {
+	handoffDir := filepath.Join(dir, ".docket", "handoff")
+	if err := os.MkdirAll(handoffDir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(handoffDir, data.Feature.ID+".md")
+
+	baseline := Render(data, cpData)
+
+	// Preserve enrichment sections from board-manager if they exist
+	if existing, err := os.ReadFile(path); err == nil {
+		enrichment := ExtractEnrichmentSections(string(existing))
+		if enrichment != "" {
+			baseline = strings.TrimRight(baseline, "\n") + "\n" + enrichment
+		}
+	}
+
+	return os.WriteFile(path, []byte(baseline), 0644)
+}
+
+// ExtractEnrichmentSections pulls board-manager-written sections from an
+// existing handoff file. Returns the combined text or "" if none found.
+func ExtractEnrichmentSections(content string) string {
+	var sections []string
+	for _, heading := range enrichmentHeadings {
+		idx := strings.Index(content, heading)
+		if idx < 0 {
+			continue
+		}
+		section := content[idx:]
+		// Find end: next ## heading that isn't one of our enrichment headings,
+		// or EOF
+		rest := section[len(heading):]
+		endIdx := strings.Index(rest, "\n## ")
+		if endIdx >= 0 {
+			// Check if the next heading is another enrichment heading
+			nextSection := rest[endIdx+1:]
+			isEnrichment := false
+			for _, eh := range enrichmentHeadings {
+				if strings.HasPrefix(nextSection, eh) {
+					isEnrichment = true
+					break
+				}
+			}
+			if !isEnrichment {
+				section = section[:len(heading)+endIdx+1]
+			}
+		}
+		sections = append(sections, strings.TrimRight(section, "\n"))
+	}
+	if len(sections) == 0 {
+		return ""
+	}
+	return "\n" + strings.Join(sections, "\n\n") + "\n"
+}
+
+// CleanStale removes handoff files for features not in the activeIDs set.
+func CleanStale(dir string, activeIDs map[string]bool) {
+	handoffDir := filepath.Join(dir, ".docket", "handoff")
+	entries, err := os.ReadDir(handoffDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".md")
+		if !activeIDs[name] {
+			os.Remove(filepath.Join(handoffDir, e.Name()))
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,11 +6,11 @@ import (
 	"github.com/sniffle6/claude-docket/internal/store"
 )
 
-func NewServer(s *store.Store) *server.MCPServer {
+func NewServer(s *store.Store, projectDir string) *server.MCPServer {
 	srv := server.NewMCPServer("docket", "0.1.0",
 		server.WithToolCapabilities(true),
 	)
 
-	registerTools(srv, s)
+	registerTools(srv, s, projectDir)
 	return srv
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -23,7 +23,7 @@ func registerTools(srv *server.MCPServer, s *store.Store) {
 	srv.AddTool(mcp.NewTool("update_feature",
 		mcp.WithDescription("Update a feature's status, description, left_off note, notes, worktree_path, or key_files."),
 		mcp.WithString("id", mcp.Required(), mcp.Description("Feature slug ID")),
-		mcp.WithString("status", mcp.Description("New status: planned, in_progress, done, blocked, dev_complete")),
+		mcp.WithString("status", mcp.Description("New status: planned, in_progress, done, blocked, dev_complete, archived")),
 		mcp.WithString("title", mcp.Description("New title")),
 		mcp.WithString("description", mcp.Description("New description")),
 		mcp.WithString("left_off", mcp.Description("Where work stopped — free text")),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sniffle6/claude-docket/internal/store"
 )
 
-func registerTools(srv *server.MCPServer, s *store.Store) {
+func registerTools(srv *server.MCPServer, s *store.Store, projectDir string) {
 	srv.AddTool(mcp.NewTool("add_feature",
 		mcp.WithDescription("Create a new feature to track. Returns the generated slug ID."),
 		mcp.WithString("title", mcp.Required(), mcp.Description("Feature title (e.g., 'Bluetooth Panel')")),
@@ -126,6 +126,11 @@ func registerTools(srv *server.MCPServer, s *store.Store) {
 		mcp.WithString("outcome", mcp.Required(), mcp.Description("accepted or rejected")),
 		mcp.WithString("reason", mcp.Required(), mcp.Description("Why — one-liner (e.g., 'Too complex for MVP, polling sufficient')")),
 	), addDecisionHandler(s))
+
+	srv.AddTool(mcp.NewTool("checkpoint",
+		mcp.WithDescription("Force a checkpoint of the current session's semantic and mechanical state. Enqueues a background summarization job. Pass end_session=true to also close the work session and write the handoff file."),
+		mcp.WithBoolean("end_session", mcp.Description("If true, close the work session and write handoff after checkpointing. Default: false.")),
+	), checkpointHandler(s, projectDir))
 }
 
 func parseInt64(s string) int64 {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -17,6 +17,7 @@ func registerTools(srv *server.MCPServer, s *store.Store) {
 		mcp.WithString("status", mcp.Description("Initial status: planned (default), in_progress, blocked, dev_complete")),
 		mcp.WithString("notes", mcp.Description("User notes — thoughts, ideas, context for Claude to read when picking up this feature")),
 		mcp.WithString("type", mcp.Description("Feature type: feature, bugfix, chore, spike. Auto-creates subtasks from template when set.")),
+		mcp.WithString("tags", mcp.Description("Comma-separated tags (e.g., 'auth,frontend'). New tags trigger a warning listing existing tags.")),
 	), addFeatureHandler(s))
 
 	srv.AddTool(mcp.NewTool("update_feature",
@@ -29,13 +30,15 @@ func registerTools(srv *server.MCPServer, s *store.Store) {
 		mcp.WithString("notes", mcp.Description("User notes — thoughts, ideas, context for Claude")),
 		mcp.WithString("worktree_path", mcp.Description("Absolute path to git worktree")),
 		mcp.WithString("key_files", mcp.Description("Comma-separated list of key file paths for this feature")),
+		mcp.WithString("tags", mcp.Description("Comma-separated tags — replaces all existing tags. New tags trigger a warning.")),
 		mcp.WithBoolean("force", mcp.Description("Force status=done even with unchecked task items or open issues. Logs a decision.")),
 		mcp.WithString("force_reason", mcp.Description("Reason for force-completing (logged as a decision)")),
 	), updateFeatureHandler(s))
 
 	srv.AddTool(mcp.NewTool("list_features",
-		mcp.WithDescription("List all features. Returns compact summaries: ID, title, status, left_off snippet. Filter by status optionally."),
-		mcp.WithString("status", mcp.Description("Filter by status: planned, in_progress, done, blocked, dev_complete. Omit for all.")),
+		mcp.WithDescription("List features. Returns compact summaries: ID, title, status, tags, left_off snippet. Excludes archived by default."),
+		mcp.WithString("status", mcp.Description("Filter by status: planned, in_progress, done, blocked, dev_complete, archived. Omit for all (excluding archived).")),
+		mcp.WithString("tag", mcp.Description("Filter to features with this tag. Combines with status filter.")),
 	), listFeaturesHandler(s))
 
 	srv.AddTool(mcp.NewTool("get_feature",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -46,14 +46,6 @@ func registerTools(srv *server.MCPServer, s *store.Store) {
 		mcp.WithString("id", mcp.Required(), mcp.Description("Feature slug ID")),
 	), getFeatureHandler(s))
 
-	srv.AddTool(mcp.NewTool("log_session",
-		mcp.WithDescription("Record a session summary. Call this at end of session to log what was accomplished."),
-		mcp.WithString("feature_id", mcp.Required(), mcp.Description("Feature slug ID this session was about.")),
-		mcp.WithString("summary", mcp.Required(), mcp.Description("Brief summary of what was accomplished")),
-		mcp.WithString("files_touched", mcp.Description("Comma-separated list of files modified this session")),
-		mcp.WithString("commits", mcp.Description("Comma-separated list of commit hashes made this session")),
-	), logSessionHandler(s))
-
 	srv.AddTool(mcp.NewTool("get_context",
 		mcp.WithDescription("Get a token-efficient briefing for a feature: status, where we left off, worktree path, recent sessions, key files. ~15-20 lines."),
 		mcp.WithString("id", mcp.Required(), mcp.Description("Feature slug ID")),

--- a/internal/mcp/tools_checkpoint.go
+++ b/internal/mcp/tools_checkpoint.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/sniffle6/claude-docket/internal/handoff"
 	"github.com/sniffle6/claude-docket/internal/store"
 	"github.com/sniffle6/claude-docket/internal/transcript"
 )
@@ -75,7 +76,7 @@ func checkpointHandler(s *store.Store, projectDir string) server.ToolHandlerFunc
 		if endSession {
 			data, err := s.GetHandoffData(ws.FeatureID)
 			if err == nil {
-				writeHandoffFileFromMCP(projectDir, data)
+				handoff.WriteFile(projectDir, data, nil)
 			}
 			s.CloseWorkSession(ws.ID)
 
@@ -117,39 +118,3 @@ func findTranscriptPath(claudeSessionID string) string {
 	return ""
 }
 
-// writeHandoffFileFromMCP writes a handoff file from the MCP context.
-// This is a simplified version that doesn't include checkpoint data
-// (the checkpoint we just enqueued hasn't been processed yet).
-func writeHandoffFileFromMCP(dir string, data *store.HandoffData) error {
-	handoffDir := filepath.Join(dir, ".docket", "handoff")
-	if err := os.MkdirAll(handoffDir, 0755); err != nil {
-		return err
-	}
-	path := filepath.Join(handoffDir, data.Feature.ID+".md")
-
-	// Use a simple render without checkpoint data
-	var b strings.Builder
-	f := data.Feature
-	fmt.Fprintf(&b, "# Handoff: %s\n\n", f.Title)
-	fmt.Fprintf(&b, "## Status\n%s | Progress: %d/%d | Updated: %s\n\n",
-		f.Status, data.Done, data.Total, f.UpdatedAt.Format("2006-01-02 15:04"))
-	if f.LeftOff != "" {
-		fmt.Fprintf(&b, "## Left Off\n%s\n\n", f.LeftOff)
-	}
-	if len(data.NextTasks) > 0 {
-		b.WriteString("## Next Tasks\n")
-		for _, task := range data.NextTasks {
-			fmt.Fprintf(&b, "- [ ] %s\n", task)
-		}
-		b.WriteString("\n")
-	}
-	if len(f.KeyFiles) > 0 {
-		b.WriteString("## Key Files\n")
-		for _, kf := range f.KeyFiles {
-			fmt.Fprintf(&b, "- %s\n", kf)
-		}
-		b.WriteString("\n")
-	}
-
-	return os.WriteFile(path, []byte(b.String()), 0644)
-}

--- a/internal/mcp/tools_checkpoint.go
+++ b/internal/mcp/tools_checkpoint.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/sniffle6/claude-docket/internal/store"
+	"github.com/sniffle6/claude-docket/internal/transcript"
+)
+
+func checkpointHandler(s *store.Store, projectDir string) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		endSession := false
+		if v, ok := args["end_session"]; ok {
+			if b, ok := v.(bool); ok {
+				endSession = b
+			}
+		}
+
+		ws, err := s.GetActiveWorkSession()
+		if err != nil {
+			return mcp.NewToolResultError("no active work session — nothing to checkpoint"), nil
+		}
+
+		// Read transcript offset
+		offsetPath := filepath.Join(projectDir, ".docket", "transcript-offset")
+		var startOffset int64
+		if data, err := os.ReadFile(offsetPath); err == nil {
+			fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &startOffset)
+		}
+
+		// Find transcript path
+		transcriptPath := findTranscriptPath(ws.ClaudeSessionID)
+
+		var delta *transcript.Delta
+		if transcriptPath != "" {
+			var parseErr error
+			delta, parseErr = transcript.Parse(transcriptPath, startOffset)
+			if parseErr != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("parse transcript: %v", parseErr)), nil
+			}
+		} else {
+			delta = &transcript.Delta{EndOffset: startOffset}
+		}
+
+		reason := "manual_checkpoint"
+		if endSession {
+			reason = "manual_end_session"
+		}
+
+		job, err := s.EnqueueCheckpointJob(store.CheckpointJobInput{
+			WorkSessionID:         ws.ID,
+			FeatureID:             ws.FeatureID,
+			Reason:                reason,
+			TriggerType:           "manual",
+			TranscriptStartOffset: startOffset,
+			TranscriptEndOffset:   delta.EndOffset,
+			SemanticText:          delta.SemanticText,
+			MechanicalFacts:       delta.MechanicalFacts,
+		})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("enqueue checkpoint: %v", err)), nil
+		}
+
+		// Update offset
+		os.WriteFile(offsetPath, []byte(fmt.Sprintf("%d", delta.EndOffset)), 0644)
+
+		if endSession {
+			data, err := s.GetHandoffData(ws.FeatureID)
+			if err == nil {
+				writeHandoffFileFromMCP(projectDir, data)
+			}
+			s.CloseWorkSession(ws.ID)
+
+			return mcp.NewToolResultText(fmt.Sprintf(
+				"Work session closed for feature %q. Checkpoint #%d enqueued. Handoff written.",
+				ws.FeatureID, job.ID,
+			)), nil
+		}
+
+		return mcp.NewToolResultText(fmt.Sprintf(
+			"Checkpoint #%d enqueued for feature %q. %d chars semantic text, %d files edited.",
+			job.ID, ws.FeatureID, len(delta.SemanticText), len(delta.MechanicalFacts.FilesEdited),
+		)), nil
+	}
+}
+
+func findTranscriptPath(claudeSessionID string) string {
+	if claudeSessionID == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	projectsDir := filepath.Join(home, ".claude", "projects")
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(projectsDir, entry.Name(), claudeSessionID+".jsonl")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// writeHandoffFileFromMCP writes a handoff file from the MCP context.
+// This is a simplified version that doesn't include checkpoint data
+// (the checkpoint we just enqueued hasn't been processed yet).
+func writeHandoffFileFromMCP(dir string, data *store.HandoffData) error {
+	handoffDir := filepath.Join(dir, ".docket", "handoff")
+	if err := os.MkdirAll(handoffDir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(handoffDir, data.Feature.ID+".md")
+
+	// Use a simple render without checkpoint data
+	var b strings.Builder
+	f := data.Feature
+	fmt.Fprintf(&b, "# Handoff: %s\n\n", f.Title)
+	fmt.Fprintf(&b, "## Status\n%s | Progress: %d/%d | Updated: %s\n\n",
+		f.Status, data.Done, data.Total, f.UpdatedAt.Format("2006-01-02 15:04"))
+	if f.LeftOff != "" {
+		fmt.Fprintf(&b, "## Left Off\n%s\n\n", f.LeftOff)
+	}
+	if len(data.NextTasks) > 0 {
+		b.WriteString("## Next Tasks\n")
+		for _, task := range data.NextTasks {
+			fmt.Fprintf(&b, "- [ ] %s\n", task)
+		}
+		b.WriteString("\n")
+	}
+	if len(f.KeyFiles) > 0 {
+		b.WriteString("## Key Files\n")
+		for _, kf := range f.KeyFiles {
+			fmt.Fprintf(&b, "- %s\n", kf)
+		}
+		b.WriteString("\n")
+	}
+
+	return os.WriteFile(path, []byte(b.String()), 0644)
+}

--- a/internal/mcp/tools_feature.go
+++ b/internal/mcp/tools_feature.go
@@ -41,10 +41,27 @@ func addFeatureHandler(s *store.Store) server.ToolHandlerFunc {
 			}
 			s.UpdateFeature(f.ID, store.FeatureUpdate{Type: &typ})
 		}
+		var tagWarning string
+		if tagStr, ok := argString(args, "tags"); ok && tagStr != "" {
+			tags := strings.Split(tagStr, ",")
+			for i := range tags {
+				tags[i] = strings.TrimSpace(tags[i])
+			}
+			s.UpdateFeature(f.ID, store.FeatureUpdate{Tags: &tags})
+			newTags := s.CheckNewTags(tags)
+			if len(newTags) > 0 {
+				known, _ := s.GetKnownTags()
+				tagWarning = fmt.Sprintf("\nNote: new tag(s) %q added. Existing tags: %s", strings.Join(newTags, ", "), strings.Join(known, ", "))
+			}
+		}
 		f, _ = s.GetFeature(f.ID)
 
 		data, _ := json.MarshalIndent(f, "", "  ")
-		return mcp.NewToolResultText(string(data)), nil
+		result := string(data)
+		if tagWarning != "" {
+			result += tagWarning
+		}
+		return mcp.NewToolResultText(result), nil
 	}
 }
 
@@ -82,6 +99,13 @@ func updateFeatureHandler(s *store.Store) server.ToolHandlerFunc {
 			}
 			u.KeyFiles = &files
 		}
+		if v, ok := argString(args, "tags"); ok {
+			tags := strings.Split(v, ",")
+			for i := range tags {
+				tags[i] = strings.TrimSpace(tags[i])
+			}
+			u.Tags = &tags
+		}
 		if v, ok := args["force"]; ok {
 			if b, ok := v.(bool); ok && b {
 				force := true
@@ -96,15 +120,31 @@ func updateFeatureHandler(s *store.Store) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		return mcp.NewToolResultText(fmt.Sprintf("Updated feature %q", id)), nil
+		msg := fmt.Sprintf("Updated feature %q", id)
+		if u.Tags != nil {
+			newTags := s.CheckNewTags(*u.Tags)
+			if len(newTags) > 0 {
+				known, _ := s.GetKnownTags()
+				msg += fmt.Sprintf("\nNote: new tag(s) %q added. Existing tags: %s", strings.Join(newTags, ", "), strings.Join(known, ", "))
+			}
+		}
+		return mcp.NewToolResultText(msg), nil
 	}
 }
 
 func listFeaturesHandler(s *store.Store) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		status, _ := argString(req.GetArguments(), "status")
+		args := req.GetArguments()
+		status, _ := argString(args, "status")
+		tag, _ := argString(args, "tag")
 
-		features, err := s.ListFeatures(status)
+		var features []store.Feature
+		var err error
+		if tag != "" {
+			features, err = s.ListFeaturesWithTag(status, tag)
+		} else {
+			features, err = s.ListFeatures(status)
+		}
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -116,6 +156,9 @@ func listFeaturesHandler(s *store.Store) server.ToolHandlerFunc {
 		var lines []string
 		for _, f := range features {
 			line := fmt.Sprintf("- **%s** [%s] %s", f.ID, f.Status, f.Title)
+			if len(f.Tags) > 0 {
+				line += fmt.Sprintf(" {%s}", strings.Join(f.Tags, ", "))
+			}
 			if f.LeftOff != "" {
 				snippet := f.LeftOff
 				if len(snippet) > 60 {

--- a/internal/mcp/tools_feature.go
+++ b/internal/mcp/tools_feature.go
@@ -43,9 +43,13 @@ func addFeatureHandler(s *store.Store) server.ToolHandlerFunc {
 		}
 		var tagWarning string
 		if tagStr, ok := argString(args, "tags"); ok && tagStr != "" {
-			tags := strings.Split(tagStr, ",")
-			for i := range tags {
-				tags[i] = strings.TrimSpace(tags[i])
+			parts := strings.Split(tagStr, ",")
+			var tags []string
+			for _, t := range parts {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					tags = append(tags, t)
+				}
 			}
 			// Check for new tags BEFORE saving so they're still "unknown"
 			newTags := s.CheckNewTags(tags)
@@ -105,9 +109,13 @@ func updateFeatureHandler(s *store.Store) server.ToolHandlerFunc {
 				empty := []string{}
 				u.Tags = &empty
 			} else {
-				tags := strings.Split(v, ",")
-				for i := range tags {
-					tags[i] = strings.TrimSpace(tags[i])
+				parts := strings.Split(v, ",")
+				var tags []string
+				for _, t := range parts {
+					t = strings.TrimSpace(t)
+					if t != "" {
+						tags = append(tags, t)
+					}
 				}
 				u.Tags = &tags
 			}

--- a/internal/mcp/tools_feature.go
+++ b/internal/mcp/tools_feature.go
@@ -47,12 +47,13 @@ func addFeatureHandler(s *store.Store) server.ToolHandlerFunc {
 			for i := range tags {
 				tags[i] = strings.TrimSpace(tags[i])
 			}
-			s.UpdateFeature(f.ID, store.FeatureUpdate{Tags: &tags})
+			// Check for new tags BEFORE saving so they're still "unknown"
 			newTags := s.CheckNewTags(tags)
 			if len(newTags) > 0 {
 				known, _ := s.GetKnownTags()
 				tagWarning = fmt.Sprintf("\nNote: new tag(s) %q added. Existing tags: %s", strings.Join(newTags, ", "), strings.Join(known, ", "))
 			}
+			s.UpdateFeature(f.ID, store.FeatureUpdate{Tags: &tags})
 		}
 		f, _ = s.GetFeature(f.ID)
 
@@ -100,11 +101,16 @@ func updateFeatureHandler(s *store.Store) server.ToolHandlerFunc {
 			u.KeyFiles = &files
 		}
 		if v, ok := argString(args, "tags"); ok {
-			tags := strings.Split(v, ",")
-			for i := range tags {
-				tags[i] = strings.TrimSpace(tags[i])
+			if v == "" {
+				empty := []string{}
+				u.Tags = &empty
+			} else {
+				tags := strings.Split(v, ",")
+				for i := range tags {
+					tags[i] = strings.TrimSpace(tags[i])
+				}
+				u.Tags = &tags
 			}
-			u.Tags = &tags
 		}
 		if v, ok := args["force"]; ok {
 			if b, ok := v.(bool); ok && b {
@@ -116,17 +122,23 @@ func updateFeatureHandler(s *store.Store) server.ToolHandlerFunc {
 			u.ForceReason = &v
 		}
 
+		// Check for new tags BEFORE saving so they're still "unknown"
+		var tagWarning string
+		if u.Tags != nil && len(*u.Tags) > 0 {
+			newTags := s.CheckNewTags(*u.Tags)
+			if len(newTags) > 0 {
+				known, _ := s.GetKnownTags()
+				tagWarning = fmt.Sprintf("\nNote: new tag(s) %q added. Existing tags: %s", strings.Join(newTags, ", "), strings.Join(known, ", "))
+			}
+		}
+
 		if err := s.UpdateFeature(id, u); err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
 		msg := fmt.Sprintf("Updated feature %q", id)
-		if u.Tags != nil {
-			newTags := s.CheckNewTags(*u.Tags)
-			if len(newTags) > 0 {
-				known, _ := s.GetKnownTags()
-				msg += fmt.Sprintf("\nNote: new tag(s) %q added. Existing tags: %s", strings.Join(newTags, ", "), strings.Join(known, ", "))
-			}
+		if tagWarning != "" {
+			msg += tagWarning
 		}
 		return mcp.NewToolResultText(msg), nil
 	}

--- a/internal/mcp/tools_session.go
+++ b/internal/mcp/tools_session.go
@@ -3,60 +3,12 @@ package mcp
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/sniffle6/claude-docket/internal/store"
 )
-
-func logSessionHandler(s *store.Store) server.ToolHandlerFunc {
-	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		args := req.GetArguments()
-		summary, ok := argString(args, "summary")
-		if !ok || summary == "" {
-			return mcp.NewToolResultError("missing required parameter: summary"), nil
-		}
-		featureID, ok := argString(args, "feature_id")
-		if !ok || featureID == "" {
-			return mcp.NewToolResultError("missing required parameter: feature_id"), nil
-		}
-
-		if _, err := s.GetFeature(featureID); err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("feature not found: %s", featureID)), nil
-		}
-
-		var filesTouched []string
-		if v, ok := argString(args, "files_touched"); ok && v != "" {
-			for _, f := range strings.Split(v, ",") {
-				filesTouched = append(filesTouched, strings.TrimSpace(f))
-			}
-		}
-
-		var commits []string
-		if v, ok := argString(args, "commits"); ok && v != "" {
-			for _, c := range strings.Split(v, ",") {
-				commits = append(commits, strings.TrimSpace(c))
-			}
-		}
-
-		sess, err := s.LogSession(store.SessionInput{
-			FeatureID:    featureID,
-			Summary:      summary,
-			FilesTouched: filesTouched,
-			Commits:      commits,
-			AutoLinked:   featureID != "",
-			LinkReason:   "provided by Claude at session end",
-		})
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-
-		s.MarkSessionLogged()
-		return mcp.NewToolResultText(fmt.Sprintf("Session #%d logged.", sess.ID)), nil
-	}
-}
 
 func compactSessionsHandler(s *store.Store) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -18,7 +18,7 @@ func testStore(t *testing.T) *store.Store {
 
 func TestNewServerDoesNotPanic(t *testing.T) {
 	s := testStore(t)
-	srv := NewServer(s)
+	srv := NewServer(s, t.TempDir())
 	if srv == nil {
 		t.Fatal("NewServer returned nil")
 	}
@@ -89,7 +89,7 @@ func TestFullWorkflowViaStore(t *testing.T) {
 	}
 
 	// 6. Verify MCP server creation with populated store
-	srv := NewServer(s)
+	srv := NewServer(s, t.TempDir())
 	if srv == nil {
 		t.Fatal("NewServer returned nil after workflow")
 	}

--- a/internal/store/archive_test.go
+++ b/internal/store/archive_test.go
@@ -1,0 +1,66 @@
+package store
+
+import "testing"
+
+func TestArchivedStatus(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	f, _ := s.AddFeature("Old Feature", "")
+	archived := "archived"
+	err := s.UpdateFeature(f.ID, FeatureUpdate{Status: &archived})
+	if err != nil {
+		t.Fatalf("set archived: %v", err)
+	}
+	f, _ = s.GetFeature(f.ID)
+	if f.Status != "archived" {
+		t.Fatalf("expected archived, got %q", f.Status)
+	}
+}
+
+func TestListFeaturesExcludesArchived(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Active", "")
+	s.AddFeature("Old", "")
+	archived := "archived"
+	s.UpdateFeature("old", FeatureUpdate{Status: &archived})
+
+	features, _ := s.ListFeatures("")
+	if len(features) != 1 || features[0].ID != "active" {
+		t.Fatalf("expected only active feature, got %v", features)
+	}
+}
+
+func TestListFeaturesShowArchived(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Old", "")
+	archived := "archived"
+	s.UpdateFeature("old", FeatureUpdate{Status: &archived})
+
+	features, _ := s.ListFeatures("archived")
+	if len(features) != 1 || features[0].ID != "old" {
+		t.Fatalf("expected archived feature, got %v", features)
+	}
+}
+
+func TestCompletionGateBypassForArchived(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	f, _ := s.AddFeature("Archivable", "")
+	s.ApplyTemplate(f.ID, "bugfix") // creates unchecked items
+
+	archived := "archived"
+	err := s.UpdateFeature(f.ID, FeatureUpdate{Status: &archived})
+	if err != nil {
+		t.Fatalf("archiving with unchecked items should work, got: %v", err)
+	}
+	f, _ = s.GetFeature(f.ID)
+	if f.Status != "archived" {
+		t.Fatalf("expected archived, got %q", f.Status)
+	}
+}

--- a/internal/store/archive_test.go
+++ b/internal/store/archive_test.go
@@ -64,3 +64,50 @@ func TestCompletionGateBypassForArchived(t *testing.T) {
 		t.Fatalf("expected archived, got %q", f.Status)
 	}
 }
+
+func TestAutoArchiveStale(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Old Done", "")
+	done := "done"
+	s.UpdateFeature("old-done", FeatureUpdate{Status: &done})
+
+	// Backdate updated_at to 8 days ago
+	s.DB().Exec(`UPDATE features SET updated_at = datetime('now', '-8 days') WHERE id = 'old-done'`)
+
+	s.AddFeature("Recent Done", "")
+	s.UpdateFeature("recent-done", FeatureUpdate{Status: &done})
+
+	archived, err := s.AutoArchiveStale()
+	if err != nil {
+		t.Fatalf("AutoArchiveStale: %v", err)
+	}
+	if len(archived) != 1 || archived[0] != "old-done" {
+		t.Fatalf("expected [old-done], got %v", archived)
+	}
+
+	f, _ := s.GetFeature("old-done")
+	if f.Status != "archived" {
+		t.Fatalf("expected archived, got %q", f.Status)
+	}
+
+	f, _ = s.GetFeature("recent-done")
+	if f.Status != "done" {
+		t.Fatalf("recent should still be done, got %q", f.Status)
+	}
+}
+
+func TestAutoArchiveSkipsRecent(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Fresh Done", "")
+	done := "done"
+	s.UpdateFeature("fresh-done", FeatureUpdate{Status: &done})
+
+	archived, _ := s.AutoArchiveStale()
+	if len(archived) != 0 {
+		t.Fatalf("expected no archival, got %v", archived)
+	}
+}

--- a/internal/store/checkpoint.go
+++ b/internal/store/checkpoint.go
@@ -45,6 +45,7 @@ type CheckpointJob struct {
 	MechanicalJSON        string     `json:"mechanical_json"`
 	Status                string     `json:"status"`
 	Error                 string     `json:"error"`
+	RetryCount            int        `json:"retry_count"`
 	CreatedAt             time.Time  `json:"created_at"`
 	StartedAt             *time.Time `json:"started_at"`
 	FinishedAt            *time.Time `json:"finished_at"`
@@ -155,7 +156,23 @@ func (s *Store) CompleteCheckpointJob(id int64, errMsg *string) error {
 	return err
 }
 
+const maxCheckpointRetries = 3
+
 func (s *Store) FailCheckpointJob(id int64, errMsg string) error {
+	row := s.db.QueryRow(`SELECT retry_count FROM checkpoint_jobs WHERE id = ?`, id)
+	var retryCount int
+	if err := row.Scan(&retryCount); err != nil {
+		return err
+	}
+
+	if retryCount < maxCheckpointRetries {
+		_, err := s.db.Exec(
+			`UPDATE checkpoint_jobs SET status = 'queued', retry_count = retry_count + 1, error = ?, started_at = NULL WHERE id = ?`,
+			errMsg, id,
+		)
+		return err
+	}
+
 	_, err := s.db.Exec(
 		`UPDATE checkpoint_jobs SET status = 'failed', error = ?, finished_at = datetime('now') WHERE id = ?`,
 		errMsg, id,
@@ -167,7 +184,7 @@ func (s *Store) GetCheckpointJob(id int64) (*CheckpointJob, error) {
 	row := s.db.QueryRow(
 		`SELECT id, work_session_id, feature_id, reason, trigger_type,
                 transcript_start_offset, transcript_end_offset,
-                semantic_text, mechanical_json, status, error,
+                semantic_text, mechanical_json, status, error, retry_count,
                 created_at, started_at, finished_at
          FROM checkpoint_jobs WHERE id = ?`, id,
 	)
@@ -175,7 +192,7 @@ func (s *Store) GetCheckpointJob(id int64) (*CheckpointJob, error) {
 	err := row.Scan(
 		&job.ID, &job.WorkSessionID, &job.FeatureID, &job.Reason, &job.TriggerType,
 		&job.TranscriptStartOffset, &job.TranscriptEndOffset,
-		&job.SemanticText, &job.MechanicalJSON, &job.Status, &job.Error,
+		&job.SemanticText, &job.MechanicalJSON, &job.Status, &job.Error, &job.RetryCount,
 		&job.CreatedAt, &job.StartedAt, &job.FinishedAt,
 	)
 	if err != nil {

--- a/internal/store/checkpoint.go
+++ b/internal/store/checkpoint.go
@@ -1,0 +1,264 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type FileEdit struct {
+	Path  string `json:"path"`
+	Count int    `json:"count"`
+}
+
+type TestRunFact struct {
+	Command string `json:"command"`
+	Passed  bool   `json:"passed"`
+}
+
+type CommitFact struct {
+	Hash    string `json:"hash"`
+	Message string `json:"message"`
+}
+
+type ErrorFact struct {
+	Tool    string `json:"tool"`
+	Message string `json:"message"`
+}
+
+type MechanicalFacts struct {
+	FilesEdited []FileEdit    `json:"files_edited,omitempty"`
+	TestRuns    []TestRunFact `json:"test_runs,omitempty"`
+	Commits     []CommitFact  `json:"commits,omitempty"`
+	Errors      []ErrorFact   `json:"errors,omitempty"`
+}
+
+type CheckpointJob struct {
+	ID                    int64      `json:"id"`
+	WorkSessionID         int64      `json:"work_session_id"`
+	FeatureID             string     `json:"feature_id"`
+	Reason                string     `json:"reason"`
+	TriggerType           string     `json:"trigger_type"`
+	TranscriptStartOffset int64      `json:"transcript_start_offset"`
+	TranscriptEndOffset   int64      `json:"transcript_end_offset"`
+	SemanticText          string     `json:"semantic_text"`
+	MechanicalJSON        string     `json:"mechanical_json"`
+	Status                string     `json:"status"`
+	Error                 string     `json:"error"`
+	CreatedAt             time.Time  `json:"created_at"`
+	StartedAt             *time.Time `json:"started_at"`
+	FinishedAt            *time.Time `json:"finished_at"`
+}
+
+type CheckpointJobInput struct {
+	WorkSessionID         int64
+	FeatureID             string
+	Reason                string
+	TriggerType           string
+	TranscriptStartOffset int64
+	TranscriptEndOffset   int64
+	SemanticText          string
+	MechanicalFacts       MechanicalFacts
+}
+
+type CheckpointObservation struct {
+	ID              int64     `json:"id"`
+	CheckpointJobID int64     `json:"checkpoint_job_id"`
+	WorkSessionID   int64     `json:"work_session_id"`
+	FeatureID       string    `json:"feature_id"`
+	Kind            string    `json:"kind"`
+	PayloadJSON     string    `json:"payload_json"`
+	SummaryText     string    `json:"summary_text"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+type CheckpointObservationInput struct {
+	CheckpointJobID int64
+	WorkSessionID   int64
+	FeatureID       string
+	Kind            string
+	PayloadJSON     string
+	SummaryText     string
+}
+
+// EnqueueCheckpointJob inserts a checkpoint job. Idempotent — if a job with
+// the same work_session_id + transcript offsets + feature_id already exists,
+// returns the existing job.
+func (s *Store) EnqueueCheckpointJob(input CheckpointJobInput) (*CheckpointJob, error) {
+	// Idempotency check
+	row := s.db.QueryRow(
+		`SELECT id FROM checkpoint_jobs
+         WHERE work_session_id = ? AND feature_id = ?
+           AND transcript_start_offset = ? AND transcript_end_offset = ?`,
+		input.WorkSessionID, input.FeatureID,
+		input.TranscriptStartOffset, input.TranscriptEndOffset,
+	)
+	var existingID int64
+	if err := row.Scan(&existingID); err == nil {
+		return s.GetCheckpointJob(existingID)
+	}
+
+	mechJSON, _ := json.Marshal(input.MechanicalFacts)
+	res, err := s.db.Exec(
+		`INSERT INTO checkpoint_jobs
+         (work_session_id, feature_id, reason, trigger_type,
+          transcript_start_offset, transcript_end_offset,
+          semantic_text, mechanical_json, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'queued')`,
+		input.WorkSessionID, input.FeatureID, input.Reason, input.TriggerType,
+		input.TranscriptStartOffset, input.TranscriptEndOffset,
+		input.SemanticText, string(mechJSON),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("enqueue checkpoint job: %w", err)
+	}
+	id, _ := res.LastInsertId()
+	return s.GetCheckpointJob(id)
+}
+
+// DequeueCheckpointJob atomically picks the oldest queued job and marks it running.
+func (s *Store) DequeueCheckpointJob() (*CheckpointJob, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	row := tx.QueryRow(
+		`SELECT id FROM checkpoint_jobs WHERE status = 'queued' ORDER BY id ASC LIMIT 1`,
+	)
+	var id int64
+	if err := row.Scan(&id); err != nil {
+		return nil, nil // no queued jobs
+	}
+
+	_, err = tx.Exec(
+		`UPDATE checkpoint_jobs SET status = 'running', started_at = datetime('now') WHERE id = ?`, id,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return s.GetCheckpointJob(id)
+}
+
+func (s *Store) CompleteCheckpointJob(id int64, errMsg *string) error {
+	if errMsg != nil {
+		return s.FailCheckpointJob(id, *errMsg)
+	}
+	_, err := s.db.Exec(
+		`UPDATE checkpoint_jobs SET status = 'done', finished_at = datetime('now') WHERE id = ?`, id,
+	)
+	return err
+}
+
+func (s *Store) FailCheckpointJob(id int64, errMsg string) error {
+	_, err := s.db.Exec(
+		`UPDATE checkpoint_jobs SET status = 'failed', error = ?, finished_at = datetime('now') WHERE id = ?`,
+		errMsg, id,
+	)
+	return err
+}
+
+func (s *Store) GetCheckpointJob(id int64) (*CheckpointJob, error) {
+	row := s.db.QueryRow(
+		`SELECT id, work_session_id, feature_id, reason, trigger_type,
+                transcript_start_offset, transcript_end_offset,
+                semantic_text, mechanical_json, status, error,
+                created_at, started_at, finished_at
+         FROM checkpoint_jobs WHERE id = ?`, id,
+	)
+	var job CheckpointJob
+	err := row.Scan(
+		&job.ID, &job.WorkSessionID, &job.FeatureID, &job.Reason, &job.TriggerType,
+		&job.TranscriptStartOffset, &job.TranscriptEndOffset,
+		&job.SemanticText, &job.MechanicalJSON, &job.Status, &job.Error,
+		&job.CreatedAt, &job.StartedAt, &job.FinishedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get checkpoint job %d: %w", id, err)
+	}
+	return &job, nil
+}
+
+func (s *Store) AddCheckpointObservation(input CheckpointObservationInput) (*CheckpointObservation, error) {
+	if input.PayloadJSON == "" {
+		input.PayloadJSON = "{}"
+	}
+	res, err := s.db.Exec(
+		`INSERT INTO checkpoint_observations
+         (checkpoint_job_id, work_session_id, feature_id, kind, payload_json, summary_text)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+		input.CheckpointJobID, input.WorkSessionID, input.FeatureID,
+		input.Kind, input.PayloadJSON, input.SummaryText,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("add checkpoint observation: %w", err)
+	}
+	id, _ := res.LastInsertId()
+	row := s.db.QueryRow(
+		`SELECT id, checkpoint_job_id, work_session_id, feature_id, kind, payload_json, summary_text, created_at
+         FROM checkpoint_observations WHERE id = ?`, id,
+	)
+	var obs CheckpointObservation
+	err = row.Scan(&obs.ID, &obs.CheckpointJobID, &obs.WorkSessionID, &obs.FeatureID,
+		&obs.Kind, &obs.PayloadJSON, &obs.SummaryText, &obs.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &obs, nil
+}
+
+func (s *Store) GetObservationsForWorkSession(workSessionID int64) ([]CheckpointObservation, error) {
+	rows, err := s.db.Query(
+		`SELECT id, checkpoint_job_id, work_session_id, feature_id, kind, payload_json, summary_text, created_at
+         FROM checkpoint_observations WHERE work_session_id = ? ORDER BY id ASC`, workSessionID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var obs []CheckpointObservation
+	for rows.Next() {
+		var o CheckpointObservation
+		if err := rows.Scan(&o.ID, &o.CheckpointJobID, &o.WorkSessionID, &o.FeatureID,
+			&o.Kind, &o.PayloadJSON, &o.SummaryText, &o.CreatedAt); err != nil {
+			return nil, err
+		}
+		obs = append(obs, o)
+	}
+	return obs, nil
+}
+
+// GetMechanicalFactsForWorkSession merges mechanical facts from all checkpoint
+// jobs in a work session into a single MechanicalFacts.
+func (s *Store) GetMechanicalFactsForWorkSession(workSessionID int64) (*MechanicalFacts, error) {
+	rows, err := s.db.Query(
+		`SELECT mechanical_json FROM checkpoint_jobs WHERE work_session_id = ? ORDER BY id ASC`,
+		workSessionID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	merged := &MechanicalFacts{}
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			continue
+		}
+		var facts MechanicalFacts
+		if err := json.Unmarshal([]byte(raw), &facts); err != nil {
+			continue
+		}
+		merged.FilesEdited = append(merged.FilesEdited, facts.FilesEdited...)
+		merged.TestRuns = append(merged.TestRuns, facts.TestRuns...)
+		merged.Commits = append(merged.Commits, facts.Commits...)
+		merged.Errors = append(merged.Errors, facts.Errors...)
+	}
+	return merged, nil
+}

--- a/internal/store/checkpoint_test.go
+++ b/internal/store/checkpoint_test.go
@@ -1,0 +1,244 @@
+package store
+
+import (
+	"testing"
+)
+
+func TestEnqueueCheckpointJob(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	job, err := s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TriggerType:           "auto",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   1024,
+		SemanticText:          "discussed auth token design",
+		MechanicalFacts:       MechanicalFacts{FilesEdited: []FileEdit{{Path: "auth.go", Count: 2}}},
+	})
+	if err != nil {
+		t.Fatalf("EnqueueCheckpointJob: %v", err)
+	}
+	if job.Status != "queued" {
+		t.Errorf("Status = %q, want %q", job.Status, "queued")
+	}
+	if job.FeatureID != "auth-system" {
+		t.Errorf("FeatureID = %q, want %q", job.FeatureID, "auth-system")
+	}
+}
+
+func TestDequeueCheckpointJob(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   512,
+		SemanticText:          "some text",
+		MechanicalFacts:       MechanicalFacts{},
+	})
+
+	job, err := s.DequeueCheckpointJob()
+	if err != nil {
+		t.Fatalf("DequeueCheckpointJob: %v", err)
+	}
+	if job == nil {
+		t.Fatal("expected a job, got nil")
+	}
+	if job.Status != "running" {
+		t.Errorf("Status = %q, want %q", job.Status, "running")
+	}
+
+	// Second dequeue should return nil (no more queued jobs)
+	job2, _ := s.DequeueCheckpointJob()
+	if job2 != nil {
+		t.Error("expected nil on second dequeue")
+	}
+}
+
+func TestCompleteCheckpointJob(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	enqueued, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   512,
+		SemanticText:          "text",
+		MechanicalFacts:       MechanicalFacts{},
+	})
+
+	s.DequeueCheckpointJob()
+	err := s.CompleteCheckpointJob(enqueued.ID, nil)
+	if err != nil {
+		t.Fatalf("CompleteCheckpointJob: %v", err)
+	}
+
+	job, _ := s.GetCheckpointJob(enqueued.ID)
+	if job.Status != "done" {
+		t.Errorf("Status = %q, want %q", job.Status, "done")
+	}
+}
+
+func TestFailCheckpointJob(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	enqueued, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   512,
+		SemanticText:          "text",
+		MechanicalFacts:       MechanicalFacts{},
+	})
+
+	s.DequeueCheckpointJob()
+	err := s.FailCheckpointJob(enqueued.ID, "api timeout")
+	if err != nil {
+		t.Fatalf("FailCheckpointJob: %v", err)
+	}
+
+	job, _ := s.GetCheckpointJob(enqueued.ID)
+	if job.Status != "failed" {
+		t.Errorf("Status = %q, want %q", job.Status, "failed")
+	}
+	if job.Error != "api timeout" {
+		t.Errorf("Error = %q, want %q", job.Error, "api timeout")
+	}
+}
+
+func TestAddCheckpointObservation(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	job, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   512,
+		SemanticText:          "text",
+		MechanicalFacts:       MechanicalFacts{},
+	})
+
+	obs, err := s.AddCheckpointObservation(CheckpointObservationInput{
+		CheckpointJobID: job.ID,
+		WorkSessionID:   ws.ID,
+		FeatureID:       "auth-system",
+		Kind:            "summary",
+		PayloadJSON:     `{"goals": ["implement refresh tokens"]}`,
+		SummaryText:     "Discussed token refresh design. Decided to use rotating refresh tokens.",
+	})
+	if err != nil {
+		t.Fatalf("AddCheckpointObservation: %v", err)
+	}
+	if obs.Kind != "summary" {
+		t.Errorf("Kind = %q, want %q", obs.Kind, "summary")
+	}
+}
+
+func TestGetObservationsForWorkSession(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	job, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID: ws.ID, FeatureID: "auth-system", Reason: "stop",
+		TranscriptStartOffset: 0, TranscriptEndOffset: 512,
+		SemanticText: "text", MechanicalFacts: MechanicalFacts{},
+	})
+
+	s.AddCheckpointObservation(CheckpointObservationInput{
+		CheckpointJobID: job.ID, WorkSessionID: ws.ID, FeatureID: "auth-system",
+		Kind: "summary", SummaryText: "First checkpoint",
+	})
+	s.AddCheckpointObservation(CheckpointObservationInput{
+		CheckpointJobID: job.ID, WorkSessionID: ws.ID, FeatureID: "auth-system",
+		Kind: "blocker", SummaryText: "Need API key for external service",
+	})
+
+	obs, err := s.GetObservationsForWorkSession(ws.ID)
+	if err != nil {
+		t.Fatalf("GetObservationsForWorkSession: %v", err)
+	}
+	if len(obs) != 2 {
+		t.Fatalf("got %d observations, want 2", len(obs))
+	}
+}
+
+func TestCheckpointIdempotency(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	input := CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   512,
+		SemanticText:          "text",
+		MechanicalFacts:       MechanicalFacts{},
+	}
+
+	job1, _ := s.EnqueueCheckpointJob(input)
+	job2, _ := s.EnqueueCheckpointJob(input)
+
+	if job1.ID != job2.ID {
+		t.Errorf("expected idempotent enqueue, got IDs %d and %d", job1.ID, job2.ID)
+	}
+}
+
+func TestGetMechanicalFactsForWorkSession(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	facts1 := MechanicalFacts{
+		FilesEdited: []FileEdit{{Path: "auth.go", Count: 2}},
+		Commits:     []CommitFact{{Hash: "abc123", Message: "add auth"}},
+	}
+	facts2 := MechanicalFacts{
+		FilesEdited: []FileEdit{{Path: "middleware.go", Count: 1}},
+		TestRuns:    []TestRunFact{{Command: "go test ./...", Passed: true}},
+	}
+
+	s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID: ws.ID, FeatureID: "auth-system", Reason: "stop",
+		TranscriptStartOffset: 0, TranscriptEndOffset: 512,
+		SemanticText: "text", MechanicalFacts: facts1,
+	})
+	s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID: ws.ID, FeatureID: "auth-system", Reason: "stop",
+		TranscriptStartOffset: 512, TranscriptEndOffset: 1024,
+		SemanticText: "more text", MechanicalFacts: facts2,
+	})
+
+	merged, err := s.GetMechanicalFactsForWorkSession(ws.ID)
+	if err != nil {
+		t.Fatalf("GetMechanicalFactsForWorkSession: %v", err)
+	}
+	if len(merged.FilesEdited) != 2 {
+		t.Errorf("FilesEdited = %d, want 2", len(merged.FilesEdited))
+	}
+	if len(merged.Commits) != 1 {
+		t.Errorf("Commits = %d, want 1", len(merged.Commits))
+	}
+	if len(merged.TestRuns) != 1 {
+		t.Errorf("TestRuns = %d, want 1", len(merged.TestRuns))
+	}
+}

--- a/internal/store/checkpoint_test.go
+++ b/internal/store/checkpoint_test.go
@@ -90,7 +90,61 @@ func TestCompleteCheckpointJob(t *testing.T) {
 	}
 }
 
-func TestFailCheckpointJob(t *testing.T) {
+func TestFailCheckpointJobRequeuesUnderMaxRetries(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
+
+	enqueued, _ := s.EnqueueCheckpointJob(CheckpointJobInput{
+		WorkSessionID:         ws.ID,
+		FeatureID:             "auth-system",
+		Reason:                "stop",
+		TranscriptStartOffset: 0,
+		TranscriptEndOffset:   512,
+		SemanticText:          "text",
+		MechanicalFacts:       MechanicalFacts{},
+	})
+
+	// Fail 3 times — each should re-queue (retries 1, 2, 3)
+	for i := 1; i <= maxCheckpointRetries; i++ {
+		s.DequeueCheckpointJob()
+		err := s.FailCheckpointJob(enqueued.ID, "api timeout")
+		if err != nil {
+			t.Fatalf("FailCheckpointJob (retry %d): %v", i, err)
+		}
+
+		job, _ := s.GetCheckpointJob(enqueued.ID)
+		if job.Status != "queued" {
+			t.Errorf("retry %d: Status = %q, want %q", i, job.Status, "queued")
+		}
+		if job.RetryCount != i {
+			t.Errorf("retry %d: RetryCount = %d, want %d", i, job.RetryCount, i)
+		}
+		if job.Error != "api timeout" {
+			t.Errorf("retry %d: Error = %q, want %q", i, job.Error, "api timeout")
+		}
+	}
+
+	// 4th failure — should stay failed (exceeded max retries)
+	s.DequeueCheckpointJob()
+	err := s.FailCheckpointJob(enqueued.ID, "final failure")
+	if err != nil {
+		t.Fatalf("FailCheckpointJob (final): %v", err)
+	}
+
+	job, _ := s.GetCheckpointJob(enqueued.ID)
+	if job.Status != "failed" {
+		t.Errorf("final: Status = %q, want %q", job.Status, "failed")
+	}
+	if job.Error != "final failure" {
+		t.Errorf("final: Error = %q, want %q", job.Error, "final failure")
+	}
+	if job.RetryCount != maxCheckpointRetries {
+		t.Errorf("final: RetryCount = %d, want %d", job.RetryCount, maxCheckpointRetries)
+	}
+}
+
+func TestCompleteCheckpointJobWithError(t *testing.T) {
 	s := openTestStore(t)
 	s.AddFeature("Auth System", "token auth")
 	ws, _ := s.OpenWorkSession("auth-system", "sess-1")
@@ -106,17 +160,19 @@ func TestFailCheckpointJob(t *testing.T) {
 	})
 
 	s.DequeueCheckpointJob()
-	err := s.FailCheckpointJob(enqueued.ID, "api timeout")
+	errMsg := "api timeout"
+	err := s.CompleteCheckpointJob(enqueued.ID, &errMsg)
 	if err != nil {
-		t.Fatalf("FailCheckpointJob: %v", err)
+		t.Fatalf("CompleteCheckpointJob with error: %v", err)
 	}
 
+	// Should be re-queued (first failure, under max retries)
 	job, _ := s.GetCheckpointJob(enqueued.ID)
-	if job.Status != "failed" {
-		t.Errorf("Status = %q, want %q", job.Status, "failed")
+	if job.Status != "queued" {
+		t.Errorf("Status = %q, want %q", job.Status, "queued")
 	}
-	if job.Error != "api timeout" {
-		t.Errorf("Error = %q, want %q", job.Error, "api timeout")
+	if job.RetryCount != 1 {
+		t.Errorf("RetryCount = %d, want 1", job.RetryCount)
 	}
 }
 

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -88,6 +88,10 @@ const schemaV7 = `
 ALTER TABLE features ADD COLUMN type TEXT NOT NULL DEFAULT '';
 `
 
+const schemaV8 = `
+ALTER TABLE features ADD COLUMN tags TEXT NOT NULL DEFAULT '[]';
+`
+
 func migrate(db *sql.DB) error {
 	if _, err := db.Exec(schemaV1); err != nil {
 		return err
@@ -104,5 +108,7 @@ func migrate(db *sql.DB) error {
 	db.Exec(schemaV6)
 	// v7: add type column to features (ignore error if already exists)
 	db.Exec(schemaV7)
+	// v8: add tags column to features (ignore error if already exists)
+	db.Exec(schemaV8)
 	return nil
 }

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -155,6 +155,10 @@ DROP TABLE IF EXISTS checkpoint_jobs;
 ALTER TABLE checkpoint_jobs_new RENAME TO checkpoint_jobs;
 `
 
+const schemaV11 = `
+ALTER TABLE checkpoint_jobs ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;
+`
+
 func migrate(db *sql.DB) error {
 	if _, err := db.Exec(schemaV1); err != nil {
 		return err
@@ -177,5 +181,7 @@ func migrate(db *sql.DB) error {
 	db.Exec(schemaV9)
 	// v10: add 'session_end' to checkpoint_jobs reason CHECK constraint
 	db.Exec(schemaV10)
+	// v11: add retry_count column to checkpoint_jobs
+	db.Exec(schemaV11)
 	return nil
 }

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -92,6 +92,46 @@ const schemaV8 = `
 ALTER TABLE features ADD COLUMN tags TEXT NOT NULL DEFAULT '[]';
 `
 
+const schemaV9 = `
+CREATE TABLE IF NOT EXISTS work_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id TEXT NOT NULL REFERENCES features(id),
+    claude_session_id TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'closed')),
+    started_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    ended_at DATETIME,
+    handoff_stale INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS checkpoint_jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    work_session_id INTEGER NOT NULL REFERENCES work_sessions(id),
+    feature_id TEXT NOT NULL,
+    reason TEXT NOT NULL CHECK(reason IN ('stop', 'precompact', 'manual_checkpoint', 'manual_end_session')),
+    trigger_type TEXT NOT NULL DEFAULT '',
+    transcript_start_offset INTEGER NOT NULL DEFAULT 0,
+    transcript_end_offset INTEGER NOT NULL DEFAULT 0,
+    semantic_text TEXT NOT NULL DEFAULT '',
+    mechanical_json TEXT NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'queued' CHECK(status IN ('queued', 'running', 'done', 'failed', 'skipped')),
+    error TEXT NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    started_at DATETIME,
+    finished_at DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS checkpoint_observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    checkpoint_job_id INTEGER NOT NULL REFERENCES checkpoint_jobs(id),
+    work_session_id INTEGER NOT NULL REFERENCES work_sessions(id),
+    feature_id TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK(kind IN ('summary', 'blocker', 'decision_candidate', 'dead_end', 'next_step', 'gotcha')),
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    summary_text TEXT NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+`
+
 func migrate(db *sql.DB) error {
 	if _, err := db.Exec(schemaV1); err != nil {
 		return err
@@ -110,5 +150,7 @@ func migrate(db *sql.DB) error {
 	db.Exec(schemaV7)
 	// v8: add tags column to features (ignore error if already exists)
 	db.Exec(schemaV8)
+	// v9: add work_sessions, checkpoint_jobs, checkpoint_observations tables
+	db.Exec(schemaV9)
 	return nil
 }

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -132,6 +132,29 @@ CREATE TABLE IF NOT EXISTS checkpoint_observations (
 );
 `
 
+const schemaV10 = `
+CREATE TABLE IF NOT EXISTS checkpoint_jobs_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    work_session_id INTEGER NOT NULL REFERENCES work_sessions(id),
+    feature_id TEXT NOT NULL,
+    reason TEXT NOT NULL CHECK(reason IN ('stop', 'precompact', 'manual_checkpoint', 'manual_end_session', 'session_end')),
+    trigger_type TEXT NOT NULL DEFAULT '',
+    transcript_start_offset INTEGER NOT NULL DEFAULT 0,
+    transcript_end_offset INTEGER NOT NULL DEFAULT 0,
+    semantic_text TEXT NOT NULL DEFAULT '',
+    mechanical_json TEXT NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'queued' CHECK(status IN ('queued', 'running', 'done', 'failed', 'skipped')),
+    error TEXT NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    started_at DATETIME,
+    finished_at DATETIME
+);
+
+INSERT OR IGNORE INTO checkpoint_jobs_new SELECT * FROM checkpoint_jobs;
+DROP TABLE IF EXISTS checkpoint_jobs;
+ALTER TABLE checkpoint_jobs_new RENAME TO checkpoint_jobs;
+`
+
 func migrate(db *sql.DB) error {
 	if _, err := db.Exec(schemaV1); err != nil {
 		return err
@@ -152,5 +175,7 @@ func migrate(db *sql.DB) error {
 	db.Exec(schemaV8)
 	// v9: add work_sessions, checkpoint_jobs, checkpoint_observations tables
 	db.Exec(schemaV9)
+	// v10: add 'session_end' to checkpoint_jobs reason CHECK constraint
+	db.Exec(schemaV10)
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -90,6 +90,31 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
+func (s *Store) DB() *sql.DB {
+	return s.db
+}
+
+func (s *Store) AutoArchiveStale() ([]string, error) {
+	rows, err := s.db.Query(`SELECT id FROM features WHERE status = 'done' AND updated_at < datetime('now', '-7 days')`)
+	if err != nil {
+		return nil, fmt.Errorf("query stale features: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		rows.Scan(&id)
+		ids = append(ids, id)
+	}
+
+	archived := "archived"
+	for _, id := range ids {
+		s.UpdateFeature(id, FeatureUpdate{Status: &archived})
+	}
+	return ids, nil
+}
+
 // MarkSessionLogged writes a sentinel file so the Stop hook knows
 // log_session was called (avoids complex commit-matching logic).
 func (s *Store) MarkSessionLogged() {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -227,6 +227,8 @@ func (s *Store) ListFeatures(status string) ([]Feature, error) {
 	if status != "" {
 		query += " WHERE status = ?"
 		args = append(args, status)
+	} else {
+		query += " WHERE status != 'archived'"
 	}
 	query += " ORDER BY updated_at DESC"
 	rows, err := s.db.Query(query, args...)
@@ -260,6 +262,8 @@ func (s *Store) ListFeaturesWithTag(status, tag string) ([]Feature, error) {
 	if status != "" {
 		query += " AND status = ?"
 		args = append(args, status)
+	} else {
+		query += " AND status != 'archived'"
 	}
 	query += " ORDER BY updated_at DESC"
 	rows, err := s.db.Query(query, args...)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -122,23 +122,6 @@ func (s *Store) AutoArchiveStale() ([]string, error) {
 	return archivedIDs, nil
 }
 
-// MarkSessionLogged writes a sentinel file so the Stop hook knows
-// log_session was called (avoids complex commit-matching logic).
-func (s *Store) MarkSessionLogged() {
-	os.WriteFile(filepath.Join(s.dir, "session-logged"), []byte{}, 0644)
-}
-
-// WasSessionLogged checks if the sentinel file exists.
-func (s *Store) WasSessionLogged() bool {
-	_, err := os.Stat(filepath.Join(s.dir, "session-logged"))
-	return err == nil
-}
-
-// ClearSessionLogged removes the sentinel file.
-func (s *Store) ClearSessionLogged() {
-	os.Remove(filepath.Join(s.dir, "session-logged"))
-}
-
 func (s *Store) AddFeature(title, description string) (*Feature, error) {
 	id := slugify(title)
 	now := time.Now().UTC()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -251,6 +252,80 @@ func (s *Store) ListFeatures(status string) ([]Feature, error) {
 		features = append(features, f)
 	}
 	return features, nil
+}
+
+func (s *Store) ListFeaturesWithTag(status, tag string) ([]Feature, error) {
+	query := `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE tags LIKE ?`
+	args := []any{"%" + `"` + tag + `"` + "%"}
+	if status != "" {
+		query += " AND status = ?"
+		args = append(args, status)
+	}
+	query += " ORDER BY updated_at DESC"
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list features by tag: %w", err)
+	}
+	defer rows.Close()
+	var features []Feature
+	for rows.Next() {
+		var f Feature
+		var keyFilesJSON, tagsJSON string
+		if err := rows.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &tagsJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan feature: %w", err)
+		}
+		json.Unmarshal([]byte(keyFilesJSON), &f.KeyFiles)
+		if f.KeyFiles == nil {
+			f.KeyFiles = []string{}
+		}
+		json.Unmarshal([]byte(tagsJSON), &f.Tags)
+		if f.Tags == nil {
+			f.Tags = []string{}
+		}
+		features = append(features, f)
+	}
+	return features, nil
+}
+
+func (s *Store) GetKnownTags() ([]string, error) {
+	rows, err := s.db.Query(`SELECT tags FROM features WHERE tags != '[]'`)
+	if err != nil {
+		return nil, fmt.Errorf("get known tags: %w", err)
+	}
+	defer rows.Close()
+
+	seen := make(map[string]bool)
+	for rows.Next() {
+		var tagsJSON string
+		rows.Scan(&tagsJSON)
+		var tags []string
+		json.Unmarshal([]byte(tagsJSON), &tags)
+		for _, t := range tags {
+			seen[t] = true
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for t := range seen {
+		result = append(result, t)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func (s *Store) CheckNewTags(tags []string) []string {
+	known, _ := s.GetKnownTags()
+	knownSet := make(map[string]bool, len(known))
+	for _, t := range known {
+		knownSet[t] = true
+	}
+	var newTags []string
+	for _, t := range tags {
+		if !knownSet[t] {
+			newTags = append(newTags, t)
+		}
+	}
+	return newTags
 }
 
 type Session struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -104,15 +104,22 @@ func (s *Store) AutoArchiveStale() ([]string, error) {
 	var ids []string
 	for rows.Next() {
 		var id string
-		rows.Scan(&id)
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan stale feature id: %w", err)
+		}
 		ids = append(ids, id)
 	}
 
 	archived := "archived"
+	var archivedIDs []string
 	for _, id := range ids {
-		s.UpdateFeature(id, FeatureUpdate{Status: &archived})
+		if err := s.UpdateFeature(id, FeatureUpdate{Status: &archived}); err != nil {
+			fmt.Fprintf(os.Stderr, "docket: auto-archive %q: %v\n", id, err)
+			continue
+		}
+		archivedIDs = append(archivedIDs, id)
 	}
-	return ids, nil
+	return archivedIDs, nil
 }
 
 // MarkSessionLogged writes a sentinel file so the Stop hook knows
@@ -282,8 +289,9 @@ func (s *Store) ListFeatures(status string) ([]Feature, error) {
 }
 
 func (s *Store) ListFeaturesWithTag(status, tag string) ([]Feature, error) {
-	query := `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE tags LIKE ?`
-	args := []any{"%" + `"` + tag + `"` + "%"}
+	query := `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE tags LIKE ? ESCAPE '\'`
+	escaped := strings.NewReplacer("%", "\\%", "_", "\\_").Replace(tag)
+	args := []any{"%" + `"` + escaped + `"` + "%"}
 	if status != "" {
 		query += " AND status = ?"
 		args = append(args, status)
@@ -326,9 +334,13 @@ func (s *Store) GetKnownTags() ([]string, error) {
 	seen := make(map[string]bool)
 	for rows.Next() {
 		var tagsJSON string
-		rows.Scan(&tagsJSON)
+		if err := rows.Scan(&tagsJSON); err != nil {
+			continue
+		}
 		var tags []string
-		json.Unmarshal([]byte(tagsJSON), &tags)
+		if err := json.Unmarshal([]byte(tagsJSON), &tags); err != nil {
+			continue
+		}
 		for _, t := range tags {
 			seen[t] = true
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -22,6 +22,7 @@ type Feature struct {
 	LeftOff      string    `json:"left_off"`
 	Notes        string    `json:"notes"`
 	KeyFiles     []string  `json:"key_files"`
+	Tags         []string  `json:"tags"`
 	WorktreePath string    `json:"worktree_path"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
@@ -35,6 +36,7 @@ type FeatureUpdate struct {
 	LeftOff      *string   `json:"left_off,omitempty"`
 	Notes        *string   `json:"notes,omitempty"`
 	KeyFiles     *[]string `json:"key_files,omitempty"`
+	Tags         *[]string `json:"tags,omitempty"`
 	WorktreePath *string   `json:"worktree_path,omitempty"`
 	Force        *bool     `json:"force,omitempty"`
 	ForceReason  *string   `json:"force_reason,omitempty"`
@@ -119,18 +121,22 @@ func (s *Store) AddFeature(title, description string) (*Feature, error) {
 
 func (s *Store) GetFeature(id string) (*Feature, error) {
 	row := s.db.QueryRow(
-		`SELECT id, title, description, status, type, left_off, notes, key_files, worktree_path, created_at, updated_at FROM features WHERE id = ?`,
+		`SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE id = ?`,
 		id,
 	)
 	var f Feature
-	var keyFilesJSON string
-	err := row.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt)
+	var keyFilesJSON, tagsJSON string
+	err := row.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &tagsJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("get feature %q: %w", id, err)
 	}
 	json.Unmarshal([]byte(keyFilesJSON), &f.KeyFiles)
 	if f.KeyFiles == nil {
 		f.KeyFiles = []string{}
+	}
+	json.Unmarshal([]byte(tagsJSON), &f.Tags)
+	if f.Tags == nil {
+		f.Tags = []string{}
 	}
 	return &f, nil
 }
@@ -187,6 +193,11 @@ func (s *Store) UpdateFeature(id string, u FeatureUpdate) error {
 		sets = append(sets, "key_files = ?")
 		args = append(args, string(kf))
 	}
+	if u.Tags != nil {
+		t, _ := json.Marshal(*u.Tags)
+		sets = append(sets, "tags = ?")
+		args = append(args, string(t))
+	}
 	if u.WorktreePath != nil {
 		sets = append(sets, "worktree_path = ?")
 		args = append(args, *u.WorktreePath)
@@ -210,7 +221,7 @@ func (s *Store) UpdateFeature(id string, u FeatureUpdate) error {
 }
 
 func (s *Store) ListFeatures(status string) ([]Feature, error) {
-	query := `SELECT id, title, description, status, type, left_off, notes, key_files, worktree_path, created_at, updated_at FROM features`
+	query := `SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features`
 	var args []any
 	if status != "" {
 		query += " WHERE status = ?"
@@ -225,13 +236,17 @@ func (s *Store) ListFeatures(status string) ([]Feature, error) {
 	var features []Feature
 	for rows.Next() {
 		var f Feature
-		var keyFilesJSON string
-		if err := rows.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt); err != nil {
+		var keyFilesJSON, tagsJSON string
+		if err := rows.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &tagsJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan feature: %w", err)
 		}
 		json.Unmarshal([]byte(keyFilesJSON), &f.KeyFiles)
 		if f.KeyFiles == nil {
 			f.KeyFiles = []string{}
+		}
+		json.Unmarshal([]byte(tagsJSON), &f.Tags)
+		if f.Tags == nil {
+			f.Tags = []string{}
 		}
 		features = append(features, f)
 	}
@@ -351,7 +366,7 @@ func scanSessions(rows *sql.Rows) ([]Session, error) {
 
 func (s *Store) GetReadyFeatures() ([]Feature, error) {
 	rows, err := s.db.Query(
-		`SELECT id, title, description, status, type, left_off, notes, key_files, worktree_path, created_at, updated_at FROM features WHERE status IN ('in_progress', 'planned') ORDER BY CASE WHEN status='in_progress' THEN 0 ELSE 1 END, updated_at DESC`,
+		`SELECT id, title, description, status, type, left_off, notes, key_files, tags, worktree_path, created_at, updated_at FROM features WHERE status IN ('in_progress', 'planned') ORDER BY CASE WHEN status='in_progress' THEN 0 ELSE 1 END, updated_at DESC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get ready features: %w", err)
@@ -360,13 +375,17 @@ func (s *Store) GetReadyFeatures() ([]Feature, error) {
 	var features []Feature
 	for rows.Next() {
 		var f Feature
-		var keyFilesJSON string
-		if err := rows.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt); err != nil {
+		var keyFilesJSON, tagsJSON string
+		if err := rows.Scan(&f.ID, &f.Title, &f.Description, &f.Status, &f.Type, &f.LeftOff, &f.Notes, &keyFilesJSON, &tagsJSON, &f.WorktreePath, &f.CreatedAt, &f.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan feature: %w", err)
 		}
 		json.Unmarshal([]byte(keyFilesJSON), &f.KeyFiles)
 		if f.KeyFiles == nil {
 			f.KeyFiles = []string{}
+		}
+		json.Unmarshal([]byte(tagsJSON), &f.Tags)
+		if f.Tags == nil {
+			f.Tags = []string{}
 		}
 		features = append(features, f)
 	}

--- a/internal/store/tags_test.go
+++ b/internal/store/tags_test.go
@@ -2,6 +2,7 @@ package store
 
 import "testing"
 
+
 func TestFeatureTagsField(t *testing.T) {
 	s, _ := Open(t.TempDir())
 	defer s.Close()
@@ -19,5 +20,125 @@ func TestFeatureTagsField(t *testing.T) {
 	f, _ = s.GetFeature(f.ID)
 	if len(f.Tags) != 2 || f.Tags[0] != "auth" || f.Tags[1] != "frontend" {
 		t.Fatalf("expected [auth frontend], got %v", f.Tags)
+	}
+}
+
+func TestFeatureTagsInList(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Auth Feature", "desc")
+	s.AddFeature("UI Feature", "desc")
+
+	authTags := []string{"auth", "backend"}
+	uiTags := []string{"frontend", "ui"}
+	s.UpdateFeature("auth-feature", FeatureUpdate{Tags: &authTags})
+	s.UpdateFeature("ui-feature", FeatureUpdate{Tags: &uiTags})
+
+	features, _ := s.ListFeatures("")
+	if len(features) != 2 {
+		t.Fatalf("expected 2 features, got %d", len(features))
+	}
+	if len(features[0].Tags) == 0 {
+		t.Fatal("expected tags in list results")
+	}
+}
+
+func TestListFeaturesFilterByTag(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Auth Feature", "")
+	s.AddFeature("UI Feature", "")
+	s.AddFeature("Mixed Feature", "")
+
+	authTags := []string{"auth"}
+	uiTags := []string{"ui"}
+	mixedTags := []string{"auth", "ui"}
+	s.UpdateFeature("auth-feature", FeatureUpdate{Tags: &authTags})
+	s.UpdateFeature("ui-feature", FeatureUpdate{Tags: &uiTags})
+	s.UpdateFeature("mixed-feature", FeatureUpdate{Tags: &mixedTags})
+
+	features, err := s.ListFeaturesWithTag("", "auth")
+	if err != nil {
+		t.Fatalf("ListFeaturesWithTag: %v", err)
+	}
+	if len(features) != 2 {
+		t.Fatalf("expected 2 features with auth tag, got %d", len(features))
+	}
+
+	// Combined with status filter
+	ip := "in_progress"
+	s.UpdateFeature("auth-feature", FeatureUpdate{Status: &ip})
+	features, _ = s.ListFeaturesWithTag("in_progress", "auth")
+	if len(features) != 1 || features[0].ID != "auth-feature" {
+		t.Fatalf("expected 1 in_progress feature with auth tag, got %d", len(features))
+	}
+}
+
+func TestGetKnownTags(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	// No features — no tags
+	tags, _ := s.GetKnownTags()
+	if len(tags) != 0 {
+		t.Fatalf("expected 0 tags, got %d", len(tags))
+	}
+
+	s.AddFeature("Feature A", "")
+	s.AddFeature("Feature B", "")
+	tagsA := []string{"backend", "auth"}
+	tagsB := []string{"auth", "frontend"}
+	s.UpdateFeature("feature-a", FeatureUpdate{Tags: &tagsA})
+	s.UpdateFeature("feature-b", FeatureUpdate{Tags: &tagsB})
+
+	tags, err := s.GetKnownTags()
+	if err != nil {
+		t.Fatalf("GetKnownTags: %v", err)
+	}
+	// Should be sorted and deduplicated: auth, backend, frontend
+	if len(tags) != 3 {
+		t.Fatalf("expected 3 unique tags, got %d: %v", len(tags), tags)
+	}
+	if tags[0] != "auth" || tags[1] != "backend" || tags[2] != "frontend" {
+		t.Fatalf("expected [auth backend frontend], got %v", tags)
+	}
+}
+
+func TestCheckNewTags(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Feature A", "")
+	existing := []string{"auth", "frontend"}
+	s.UpdateFeature("feature-a", FeatureUpdate{Tags: &existing})
+
+	// "auth" exists, "frntend" is new
+	newTags := s.CheckNewTags([]string{"auth", "frntend"})
+	if len(newTags) != 1 || newTags[0] != "frntend" {
+		t.Fatalf("expected [frntend], got %v", newTags)
+	}
+
+	// All existing — no new
+	newTags = s.CheckNewTags([]string{"auth", "frontend"})
+	if len(newTags) != 0 {
+		t.Fatalf("expected no new tags, got %v", newTags)
+	}
+}
+
+func TestTagsInUpdateFeature(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	s.AddFeature("Replaceable", "")
+	tags1 := []string{"old", "stale"}
+	s.UpdateFeature("replaceable", FeatureUpdate{Tags: &tags1})
+
+	tags2 := []string{"new"}
+	s.UpdateFeature("replaceable", FeatureUpdate{Tags: &tags2})
+	f, _ := s.GetFeature("replaceable")
+	if len(f.Tags) != 1 || f.Tags[0] != "new" {
+		t.Fatalf("expected [new], got %v", f.Tags)
 	}
 }

--- a/internal/store/tags_test.go
+++ b/internal/store/tags_test.go
@@ -1,0 +1,23 @@
+package store
+
+import "testing"
+
+func TestFeatureTagsField(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	defer s.Close()
+
+	f, err := s.AddFeature("Tagged Feature", "desc")
+	if err != nil {
+		t.Fatalf("AddFeature: %v", err)
+	}
+	if len(f.Tags) != 0 {
+		t.Fatalf("expected empty tags, got %v", f.Tags)
+	}
+
+	tags := []string{"auth", "frontend"}
+	s.UpdateFeature(f.ID, FeatureUpdate{Tags: &tags})
+	f, _ = s.GetFeature(f.ID)
+	if len(f.Tags) != 2 || f.Tags[0] != "auth" || f.Tags[1] != "frontend" {
+		t.Fatalf("expected [auth frontend], got %v", f.Tags)
+	}
+}

--- a/internal/store/worksession.go
+++ b/internal/store/worksession.go
@@ -1,0 +1,88 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+type WorkSession struct {
+	ID              int64      `json:"id"`
+	FeatureID       string     `json:"feature_id"`
+	ClaudeSessionID string     `json:"claude_session_id"`
+	Status          string     `json:"status"`
+	StartedAt       time.Time  `json:"started_at"`
+	EndedAt         *time.Time `json:"ended_at"`
+	HandoffStale    bool       `json:"handoff_stale"`
+}
+
+// OpenWorkSession opens a new work session or resumes an existing open one
+// for the same feature + claude session.
+func (s *Store) OpenWorkSession(featureID, claudeSessionID string) (*WorkSession, error) {
+	// Try to resume existing open session for same feature+claude session
+	row := s.db.QueryRow(
+		`SELECT id, feature_id, claude_session_id, status, started_at, ended_at, handoff_stale
+         FROM work_sessions WHERE feature_id = ? AND claude_session_id = ? AND status = 'open'`,
+		featureID, claudeSessionID,
+	)
+	ws, err := scanWorkSession(row)
+	if err == nil {
+		return ws, nil
+	}
+
+	// Close any other open sessions (one active session at a time)
+	s.db.Exec(`UPDATE work_sessions SET status = 'closed', ended_at = datetime('now') WHERE status = 'open'`)
+
+	now := time.Now().UTC()
+	res, err := s.db.Exec(
+		`INSERT INTO work_sessions (feature_id, claude_session_id, status, started_at) VALUES (?, ?, 'open', ?)`,
+		featureID, claudeSessionID, now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert work session: %w", err)
+	}
+	id, _ := res.LastInsertId()
+	return s.GetWorkSession(id)
+}
+
+func (s *Store) GetWorkSession(id int64) (*WorkSession, error) {
+	row := s.db.QueryRow(
+		`SELECT id, feature_id, claude_session_id, status, started_at, ended_at, handoff_stale
+         FROM work_sessions WHERE id = ?`, id,
+	)
+	return scanWorkSession(row)
+}
+
+// GetActiveWorkSession returns the single open work session, or error if none.
+func (s *Store) GetActiveWorkSession() (*WorkSession, error) {
+	row := s.db.QueryRow(
+		`SELECT id, feature_id, claude_session_id, status, started_at, ended_at, handoff_stale
+         FROM work_sessions WHERE status = 'open' ORDER BY id DESC LIMIT 1`,
+	)
+	return scanWorkSession(row)
+}
+
+func (s *Store) CloseWorkSession(id int64) error {
+	_, err := s.db.Exec(
+		`UPDATE work_sessions SET status = 'closed', ended_at = datetime('now') WHERE id = ?`, id,
+	)
+	return err
+}
+
+func (s *Store) MarkHandoffStale(id int64) {
+	s.db.Exec(`UPDATE work_sessions SET handoff_stale = 1 WHERE id = ?`, id)
+}
+
+type scannable interface {
+	Scan(dest ...any) error
+}
+
+func scanWorkSession(row scannable) (*WorkSession, error) {
+	var ws WorkSession
+	var stale int
+	err := row.Scan(&ws.ID, &ws.FeatureID, &ws.ClaudeSessionID, &ws.Status, &ws.StartedAt, &ws.EndedAt, &stale)
+	if err != nil {
+		return nil, err
+	}
+	ws.HandoffStale = stale != 0
+	return &ws, nil
+}

--- a/internal/store/worksession_test.go
+++ b/internal/store/worksession_test.go
@@ -1,0 +1,84 @@
+package store
+
+import (
+	"testing"
+)
+
+func TestOpenWorkSession(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+
+	ws, err := s.OpenWorkSession("auth-system", "session-123")
+	if err != nil {
+		t.Fatalf("OpenWorkSession: %v", err)
+	}
+	if ws.FeatureID != "auth-system" {
+		t.Errorf("FeatureID = %q, want %q", ws.FeatureID, "auth-system")
+	}
+	if ws.ClaudeSessionID != "session-123" {
+		t.Errorf("ClaudeSessionID = %q, want %q", ws.ClaudeSessionID, "session-123")
+	}
+	if ws.Status != "open" {
+		t.Errorf("Status = %q, want %q", ws.Status, "open")
+	}
+}
+
+func TestOpenWorkSessionResumesExisting(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+
+	ws1, _ := s.OpenWorkSession("auth-system", "session-123")
+	ws2, _ := s.OpenWorkSession("auth-system", "session-123")
+
+	if ws1.ID != ws2.ID {
+		t.Errorf("expected same work session ID, got %d and %d", ws1.ID, ws2.ID)
+	}
+}
+
+func TestGetActiveWorkSession(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+
+	_, err := s.GetActiveWorkSession()
+	if err == nil {
+		t.Fatal("expected error when no active work session")
+	}
+
+	s.OpenWorkSession("auth-system", "session-123")
+
+	ws, err := s.GetActiveWorkSession()
+	if err != nil {
+		t.Fatalf("GetActiveWorkSession: %v", err)
+	}
+	if ws.FeatureID != "auth-system" {
+		t.Errorf("FeatureID = %q, want %q", ws.FeatureID, "auth-system")
+	}
+}
+
+func TestCloseWorkSession(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "session-123")
+
+	err := s.CloseWorkSession(ws.ID)
+	if err != nil {
+		t.Fatalf("CloseWorkSession: %v", err)
+	}
+
+	_, err = s.GetActiveWorkSession()
+	if err == nil {
+		t.Fatal("expected no active work session after close")
+	}
+}
+
+func TestMarkHandoffStale(t *testing.T) {
+	s := openTestStore(t)
+	s.AddFeature("Auth System", "token auth")
+	ws, _ := s.OpenWorkSession("auth-system", "session-123")
+
+	s.MarkHandoffStale(ws.ID)
+	ws2, _ := s.GetWorkSession(ws.ID)
+	if !ws2.HandoffStale {
+		t.Error("expected HandoffStale to be true")
+	}
+}

--- a/internal/transcript/parse.go
+++ b/internal/transcript/parse.go
@@ -1,0 +1,198 @@
+package transcript
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/sniffle6/claude-docket/internal/store"
+)
+
+// transcriptRecord represents one line in the JSONL transcript.
+type transcriptRecord struct {
+	Type    string          `json:"type"`
+	Message *messagePayload `json:"message"`
+	// tool_result fields
+	ToolUseID string          `json:"tool_use_id"`
+	Content   json.RawMessage `json:"content"`
+	IsError   bool            `json:"isError"`
+}
+
+type messagePayload struct {
+	Role    string         `json:"role"`
+	Content []contentBlock `json:"content"`
+}
+
+type contentBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	Name  string          `json:"name"`
+	ID    string          `json:"id"`
+	Input json.RawMessage `json:"input"`
+}
+
+type toolInput struct {
+	FilePath string `json:"file_path"`
+	Command  string `json:"command"`
+}
+
+var (
+	testCmdPattern = regexp.MustCompile(`(?i)(go test|npm test|pytest|jest|cargo test|make test)`)
+	commitPattern  = regexp.MustCompile(`\[[\w/.-]+ ([a-f0-9]{7,40})\] (.+)`)
+)
+
+// Parse reads a JSONL transcript from startOffset and returns a Delta
+// containing filtered semantic text and mechanical facts.
+// Returns an empty Delta (not an error) if the file doesn't exist or is empty.
+func Parse(path string, startOffset int64) (*Delta, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		// Missing file = empty delta, not an error
+		return &Delta{EndOffset: startOffset}, nil
+	}
+	defer f.Close()
+
+	if startOffset > 0 {
+		if _, err := f.Seek(startOffset, 0); err != nil {
+			return &Delta{EndOffset: startOffset}, nil
+		}
+	}
+
+	delta := &Delta{EndOffset: startOffset}
+	var semanticBuf strings.Builder
+
+	// Track pending tool uses for matching with results
+	pendingTools := make(map[string]contentBlock) // tool_use_id -> block
+	fileEditCounts := make(map[string]int)
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // up to 10MB lines
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		delta.EndOffset += int64(len(line)) + 1 // +1 for newline
+
+		var rec transcriptRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			fmt.Fprintf(os.Stderr, "docket transcript: skip malformed line: %v\n", err)
+			continue
+		}
+
+		switch rec.Type {
+		case "assistant":
+			if rec.Message == nil {
+				continue
+			}
+			for _, block := range rec.Message.Content {
+				switch block.Type {
+				case "text":
+					if block.Text != "" {
+						semanticBuf.WriteString(block.Text)
+						semanticBuf.WriteByte('\n')
+						delta.HasContent = true
+					}
+				case "tool_use":
+					pendingTools[block.ID] = block
+					processToolUse(block, fileEditCounts)
+				}
+			}
+
+		case "user":
+			if rec.Message == nil {
+				continue
+			}
+			for _, block := range rec.Message.Content {
+				if block.Type == "text" && block.Text != "" {
+					normalized := strings.ToLower(strings.TrimSpace(block.Text))
+					if !trivialUserMessages[normalized] {
+						delta.HasContent = true
+					}
+					// Include user text in semantic output regardless
+					semanticBuf.WriteString(block.Text)
+					semanticBuf.WriteByte('\n')
+				}
+			}
+
+		case "tool_result":
+			if pending, ok := pendingTools[rec.ToolUseID]; ok {
+				processToolResult(pending, rec, delta)
+				delete(pendingTools, rec.ToolUseID)
+			}
+		}
+	}
+
+	// Convert file edit counts to FileEdit slice
+	for p, count := range fileEditCounts {
+		delta.MechanicalFacts.FilesEdited = append(delta.MechanicalFacts.FilesEdited, store.FileEdit{
+			Path: p, Count: count,
+		})
+	}
+
+	delta.SemanticText = semanticBuf.String()
+
+	return delta, nil
+}
+
+func processToolUse(block contentBlock, fileEditCounts map[string]int) {
+	var ti toolInput
+	json.Unmarshal(block.Input, &ti)
+
+	switch block.Name {
+	case "Edit", "Write":
+		if ti.FilePath != "" {
+			fileEditCounts[ti.FilePath]++
+		}
+	}
+}
+
+func processToolResult(pending contentBlock, rec transcriptRecord, delta *Delta) {
+	var resultText string
+	// Content can be a string or an array
+	if err := json.Unmarshal(rec.Content, &resultText); err != nil {
+		// Try as raw string (already a string)
+		resultText = string(rec.Content)
+	}
+
+	var ti toolInput
+	json.Unmarshal(pending.Input, &ti)
+
+	// Check for errors
+	if rec.IsError {
+		delta.MechanicalFacts.Errors = append(delta.MechanicalFacts.Errors, store.ErrorFact{
+			Tool:    pending.Name,
+			Message: truncate(resultText, 200),
+		})
+	}
+
+	// Bash-specific analysis
+	if pending.Name == "Bash" {
+		// Test detection
+		if testCmdPattern.MatchString(ti.Command) {
+			passed := !rec.IsError
+			delta.MechanicalFacts.TestRuns = append(delta.MechanicalFacts.TestRuns, store.TestRunFact{
+				Command: ti.Command,
+				Passed:  passed,
+			})
+		}
+
+		// Commit detection
+		if strings.Contains(ti.Command, "git commit") {
+			if matches := commitPattern.FindStringSubmatch(resultText); len(matches) >= 3 {
+				delta.MechanicalFacts.Commits = append(delta.MechanicalFacts.Commits, store.CommitFact{
+					Hash:    matches[1],
+					Message: matches[2],
+				})
+			}
+		}
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/internal/transcript/parse.go
+++ b/internal/transcript/parse.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/sniffle6/claude-docket/internal/store"
 )
@@ -206,9 +207,12 @@ func processToolResult(pending contentBlock, rec transcriptRecord, delta *Delta)
 	}
 }
 
-func truncate(s string, max int) string {
-	if len(s) <= max {
+func truncate(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
 		return s
 	}
-	return s[:max] + "..."
+	for maxBytes > 0 && !utf8.RuneStart(s[maxBytes]) {
+		maxBytes--
+	}
+	return s[:maxBytes] + "..."
 }

--- a/internal/transcript/parse.go
+++ b/internal/transcript/parse.go
@@ -4,12 +4,24 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/sniffle6/claude-docket/internal/store"
 )
+
+type countingReader struct {
+	r     io.Reader
+	count int64
+}
+
+func (cr *countingReader) Read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	cr.count += int64(n)
+	return n, err
+}
 
 // transcriptRecord represents one line in the JSONL transcript.
 type transcriptRecord struct {
@@ -68,12 +80,12 @@ func Parse(path string, startOffset int64) (*Delta, error) {
 	pendingTools := make(map[string]contentBlock) // tool_use_id -> block
 	fileEditCounts := make(map[string]int)
 
-	scanner := bufio.NewScanner(f)
+	cr := &countingReader{r: f}
+	scanner := bufio.NewScanner(cr)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // up to 10MB lines
 
 	for scanner.Scan() {
 		line := scanner.Bytes()
-		delta.EndOffset += int64(len(line)) + 1 // +1 for newline
 
 		var rec transcriptRecord
 		if err := json.Unmarshal(line, &rec); err != nil {
@@ -122,6 +134,8 @@ func Parse(path string, startOffset int64) (*Delta, error) {
 			}
 		}
 	}
+
+	delta.EndOffset = startOffset + cr.count
 
 	// Convert file edit counts to FileEdit slice
 	for p, count := range fileEditCounts {

--- a/internal/transcript/parse.go
+++ b/internal/transcript/parse.go
@@ -92,7 +92,6 @@ func Parse(path string, startOffset int64) (*Delta, error) {
 					if block.Text != "" {
 						semanticBuf.WriteString(block.Text)
 						semanticBuf.WriteByte('\n')
-						delta.HasContent = true
 					}
 				case "tool_use":
 					pendingTools[block.ID] = block
@@ -132,6 +131,9 @@ func Parse(path string, startOffset int64) (*Delta, error) {
 	}
 
 	delta.SemanticText = semanticBuf.String()
+	if len(delta.SemanticText) >= 300 {
+		delta.HasContent = true
+	}
 
 	return delta, nil
 }

--- a/internal/transcript/parse_test.go
+++ b/internal/transcript/parse_test.go
@@ -1,0 +1,166 @@
+package transcript
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFixture(t *testing.T, lines ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	var content string
+	for _, line := range lines {
+		content += line + "\n"
+	}
+	os.WriteFile(path, []byte(content), 0644)
+	return path
+}
+
+func TestParseAssistantText(t *testing.T) {
+	path := writeFixture(t,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll fix the auth bug by updating the token validation."}]}}`,
+	)
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if delta.SemanticText == "" {
+		t.Error("expected semantic text from assistant message")
+	}
+	if !delta.HasContent {
+		t.Error("expected HasContent=true")
+	}
+}
+
+func TestParseFiltersToolResults(t *testing.T) {
+	path := writeFixture(t,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Let me read the file."},{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"/tmp/foo.go"}}]}}`,
+		`{"type":"tool_result","tool_use_id":"t1","content":"package main\nfunc main() {}"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The file looks correct."}]}}`,
+	)
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	// Should contain assistant text but not the tool result content
+	if len(delta.SemanticText) > 200 {
+		t.Errorf("semantic text too long (%d chars), likely includes tool result", len(delta.SemanticText))
+	}
+}
+
+func TestParseExtractsFileEdits(t *testing.T) {
+	path := writeFixture(t,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"/tmp/store.go","old_string":"foo","new_string":"bar"}}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Edit","input":{"file_path":"/tmp/store.go","old_string":"baz","new_string":"qux"}}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t3","name":"Write","input":{"file_path":"/tmp/new.go","content":"package new"}}]}}`,
+	)
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(delta.MechanicalFacts.FilesEdited) != 2 {
+		t.Errorf("FilesEdited = %d, want 2 (store.go counted once, new.go once)", len(delta.MechanicalFacts.FilesEdited))
+	}
+}
+
+func TestParseExtractsTestRuns(t *testing.T) {
+	path := writeFixture(t,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"go test ./..."}}]}}`,
+		`{"type":"tool_result","tool_use_id":"t1","content":"ok  \tpkg\t0.5s","isError":false}`,
+	)
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(delta.MechanicalFacts.TestRuns) != 1 {
+		t.Fatalf("TestRuns = %d, want 1", len(delta.MechanicalFacts.TestRuns))
+	}
+	if !delta.MechanicalFacts.TestRuns[0].Passed {
+		t.Error("expected test run to show as passed")
+	}
+}
+
+func TestParseExtractsErrors(t *testing.T) {
+	path := writeFixture(t,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls /nonexistent"}}]}}`,
+		`{"type":"tool_result","tool_use_id":"t1","content":"ls: cannot access '/nonexistent'","isError":true}`,
+	)
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(delta.MechanicalFacts.Errors) != 1 {
+		t.Fatalf("Errors = %d, want 1", len(delta.MechanicalFacts.Errors))
+	}
+}
+
+func TestParseFromOffset(t *testing.T) {
+	line1 := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"First message."}]}}`
+	line2 := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Second message."}]}}`
+	path := writeFixture(t, line1, line2)
+
+	// Parse from offset after first line
+	offset := int64(len(line1) + 1) // +1 for newline
+	delta, err := Parse(path, offset)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if delta.SemanticText != "Second message.\n" {
+		t.Errorf("SemanticText = %q, want only second message", delta.SemanticText)
+	}
+}
+
+func TestParseTrivialUserMessages(t *testing.T) {
+	path := writeFixture(t,
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"ok"}]}}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"thanks"}]}}`,
+	)
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if delta.HasContent {
+		t.Error("expected HasContent=false for trivial-only messages")
+	}
+}
+
+func TestParseSkipsMalformedLines(t *testing.T) {
+	path := writeFixture(t,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Good line."}]}}`,
+		`this is not json`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Another good line."}]}}`,
+	)
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if delta.SemanticText == "" {
+		t.Error("expected semantic text from non-malformed lines")
+	}
+}
+
+func TestParseMissingFile(t *testing.T) {
+	delta, err := Parse("/nonexistent/transcript.jsonl", 0)
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got: %v", err)
+	}
+	if delta.HasContent {
+		t.Error("expected empty delta for missing file")
+	}
+}
+
+func TestParseExtractsCommits(t *testing.T) {
+	path := writeFixture(t,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"git commit -m \"fix auth bug\""}}]}}`,
+		`{"type":"tool_result","tool_use_id":"t1","content":"[main abc1234] fix auth bug\n 1 file changed","isError":false}`,
+	)
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(delta.MechanicalFacts.Commits) != 1 {
+		t.Fatalf("Commits = %d, want 1", len(delta.MechanicalFacts.Commits))
+	}
+}

--- a/internal/transcript/parse_test.go
+++ b/internal/transcript/parse_test.go
@@ -3,7 +3,9 @@ package transcript
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func writeFixture(t *testing.T, lines ...string) string {
@@ -176,6 +178,16 @@ func TestParseCRLFEndOffset(t *testing.T) {
 	}
 	if delta.EndOffset != fileSize {
 		t.Errorf("EndOffset = %d, want %d (file size with CRLF endings)", delta.EndOffset, fileSize)
+	}
+}
+
+func TestTruncateUTF8Safety(t *testing.T) {
+	// 4-byte emoji: 🔥 = f0 9f 94 a5
+	// Use maxBytes=201 so the cut lands mid-emoji (byte 201 is inside a 4-byte sequence)
+	input := strings.Repeat("🔥", 60) // 240 bytes, 60 runes
+	result := truncate(input, 201)
+	if !utf8.ValidString(result) {
+		t.Error("truncate produced invalid UTF-8")
 	}
 }
 

--- a/internal/transcript/parse_test.go
+++ b/internal/transcript/parse_test.go
@@ -29,8 +29,10 @@ func TestParseAssistantText(t *testing.T) {
 	if delta.SemanticText == "" {
 		t.Error("expected semantic text from assistant message")
 	}
-	if !delta.HasContent {
-		t.Error("expected HasContent=true")
+	// Short assistant text (< 300 chars) should NOT set HasContent
+	// HasContent is a meaningful-delta threshold, not a "has any text" flag
+	if delta.HasContent {
+		t.Error("expected HasContent=false for short assistant text (< 300 chars)")
 	}
 }
 

--- a/internal/transcript/parse_test.go
+++ b/internal/transcript/parse_test.go
@@ -153,6 +153,32 @@ func TestParseMissingFile(t *testing.T) {
 	}
 }
 
+func writeCRLFFixture(t *testing.T, lines ...string) (string, int64) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	var content string
+	for _, line := range lines {
+		content += line + "\r\n"
+	}
+	os.WriteFile(path, []byte(content), 0644)
+	return path, int64(len(content))
+}
+
+func TestParseCRLFEndOffset(t *testing.T) {
+	line1 := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello from CRLF."}]}}`
+	line2 := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Second CRLF line."}]}}`
+	path, fileSize := writeCRLFFixture(t, line1, line2)
+
+	delta, err := Parse(path, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if delta.EndOffset != fileSize {
+		t.Errorf("EndOffset = %d, want %d (file size with CRLF endings)", delta.EndOffset, fileSize)
+	}
+}
+
 func TestParseExtractsCommits(t *testing.T) {
 	path := writeFixture(t,
 		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"git commit -m \"fix auth bug\""}}]}}`,

--- a/internal/transcript/types.go
+++ b/internal/transcript/types.go
@@ -1,0 +1,33 @@
+package transcript
+
+import "github.com/sniffle6/claude-docket/internal/store"
+
+// Delta is the result of parsing a transcript range. It contains
+// filtered semantic text (user/assistant only) and mechanical facts.
+type Delta struct {
+	SemanticText    string              // filtered user+assistant text
+	MechanicalFacts store.MechanicalFacts
+	EndOffset       int64 // byte offset after last processed line
+	HasContent      bool  // true if any non-trivial content found
+}
+
+// trivialUserMessages are acknowledgment-only messages that don't count
+// as meaningful user input.
+var trivialUserMessages = map[string]bool{
+	"ok":           true,
+	"okay":         true,
+	"thanks":       true,
+	"thank you":    true,
+	"continue":     true,
+	"go on":        true,
+	"run it":       true,
+	"yep":          true,
+	"yes":          true,
+	"yeah":         true,
+	"sure":         true,
+	"go":           true,
+	"do it":        true,
+	"looks good":   true,
+	"lgtm":         true,
+	"sounds good":  true,
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "*",

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -43,7 +43,31 @@
           {
             "type": "command",
             "command": "DOCKET_EXE_PATH hook",
-            "timeout": 15
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "DOCKET_EXE_PATH hook",
+            "timeout": 10
           }
         ]
       }

--- a/plugin/skills/checkpoint/SKILL.md
+++ b/plugin/skills/checkpoint/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: checkpoint
+description: Force a checkpoint of the current session's context. Preserves what was discussed, decisions made, and work done since the last checkpoint. Use when you want to save progress without ending the session.
+---
+
+# checkpoint: Save Session Context
+
+Force a semantic checkpoint of the current Docket work session.
+
+## Steps
+
+1. **Call the checkpoint MCP tool:**
+   Call `mcp__plugin_docket_docket__checkpoint` with no parameters.
+
+2. **Report the result** to the user — how many chars of semantic text and files were captured.
+
+## Notes
+
+- Checkpoints are processed in the background by the Docket summarizer worker.
+- If no API key is configured, only mechanical facts (files, tests, commits) are captured.
+- The checkpoint is bound to the currently active work session and feature.
+- If no work session is active, the tool will return an error.

--- a/plugin/skills/end-session/SKILL.md
+++ b/plugin/skills/end-session/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: end-session
+description: End the current Docket work session without closing Claude. Forces a final checkpoint, writes the handoff file, and closes the work session. Use when switching features or finishing work but keeping Claude open.
+---
+
+# end-session: End Docket Work Session
+
+End the current Docket work session and write the handoff file.
+
+## Steps
+
+1. **Ask the user** if they want to set a `left_off` note before closing:
+   > "Want to set a 'left off' note for the next session? (optional)"
+
+2. **If they provide a note**, call `mcp__plugin_docket_docket__update_feature` with `left_off`.
+
+3. **Close the work session with a final checkpoint:**
+   Call `mcp__plugin_docket_docket__checkpoint` with `end_session=true`.
+   This forces a checkpoint, writes the handoff file, and closes the work session in one call.
+
+4. **Report** that the work session has been closed and the handoff file has been written.
+
+## Notes
+
+- This does NOT close Claude — only the Docket work session.
+- The handoff file will be available at `.docket/handoff/<feature-id>.md`.
+- Starting work on a new feature after this will open a new work session.
+- This is a user-initiated action — Claude should not call this autonomously.


### PR DESCRIPTION
## Summary

- Captures what happens during Claude Code sessions by parsing conversation transcripts (JSONL), summarizing deltas via Anthropic API, and writing handoff files for session continuity
- Adds work sessions, checkpoint job queue, background summarizer worker, and two new skills (`/checkpoint`, `/end-session`)
- Includes 6 post-review fixes: cross-platform line ending offsets, `session_end` reason, checkpoint retry (max 3), shared handoff rendering, UTF-8 safe truncation, and clarifying comments

## Key changes

- **New packages:** `internal/transcript` (JSONL parser), `internal/checkpoint` (worker + Anthropic summarizer), `internal/handoff` (shared rendering), `internal/store` (work sessions + checkpoint CRUD)
- **Hooks:** Rewritten Stop hook, new PreCompact/SessionEnd hooks, checkpoint enqueueing on meaningful deltas
- **Schema:** v9 (work_sessions, checkpoint_jobs, checkpoint_observations), v10 (session_end reason), v11 (retry_count)
- **MCP tools:** `checkpoint` tool for manual context preservation
- **Skills:** `/checkpoint` and `/end-session` plugin skills

## Test plan

- [ ] `go test ./...` passes (all packages)
- [ ] Verify handoff files written at session end contain Last Session section with observations
- [ ] Verify `/checkpoint` skill enqueues a job and returns confirmation
- [ ] Verify retry: kill API mid-request, confirm job re-queues (up to 3x)
- [ ] Verify on Windows: transcript offsets stay correct across multiple Stop hook cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)